### PR TITLE
GH-10 feat(schema): add nullable field support to schema generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,96 @@ open_api_property(
 )
 ```
 
+### Use nullable for optional fields
+
+Mark fields as nullable when they can accept null values:
+
+```elixir
+# Optional field (not in required list, can be omitted or null)
+open_api_property(
+  key: :middle_name,
+  schema: %Schema{
+    type: :string,
+    nullable: true,
+    description: "Optional middle name"
+  }
+)
+
+# Required field that can be null (must be present, but can be null)
+open_api_property(
+  key: :nickname,
+  schema: %Schema{
+    type: :string,
+    nullable: true,
+    description: "Nickname (required field, but can be null)"
+  }
+)
+
+# Nullable with readOnly (optional server-generated field)
+open_api_property(
+  key: :external_id,
+  schema: %Schema{
+    type: :string,
+    format: :uuid,
+    nullable: true,
+    readOnly: true,
+    description: "External system ID (may not be set yet)"
+  }
+)
+
+# Nullable with writeOnly (optional input field)
+open_api_property(
+  key: :password,
+  schema: %Schema{
+    type: :string,
+    minLength: 8,
+    nullable: true,
+    writeOnly: true,
+    description: "Password (optional for updates)"
+  }
+)
+
+```
+
+**Schema-level nullable:**
+
+Mark entire schemas as nullable in their definition:
+
+```elixir
+# In your UIParameters module:
+defmodule MyApp.UIParameters do
+  use ExOpenApiUtils
+
+  open_api_property(
+    key: :theme,
+    schema: %Schema{type: :string, description: "UI theme"}
+  )
+
+  schema "ui_parameters" do
+    field :theme, :string
+  end
+
+  open_api_schema(
+    title: "UIParameters",
+    description: "UI configuration parameters",
+    properties: [:theme],
+    nullable: true  # The entire schema can be null
+  )
+end
+
+# Then reference it simply:
+open_api_property(
+  schema: MyApp.OpenApiSchema.UIParametersResponse,
+  key: :ui_parameters
+)
+```
+
+**Required vs Nullable:**
+- `required: [:field]` - Field must be present in the payload
+- `nullable: true` - Field can have a null value
+- `required: [:field]` + `nullable: true` - Field must be present but can be null
+- Not in required + `nullable: true` - Field can be omitted or explicitly set to null
+
 ### Use enum_schema for TypeScript enums
 
 ```elixir

--- a/lib/ex_open_api_utils/schema_definition.ex
+++ b/lib/ex_open_api_utils/schema_definition.ex
@@ -1,5 +1,5 @@
 defmodule ExOpenApiUtils.SchemaDefinition do
-  defstruct title: nil, required: [], properties: [], description: "", tags: [], type: :object
+  defstruct title: nil, required: [], properties: [], description: "", tags: [], type: :object, nullable: nil
 
   @type t :: %__MODULE__{
           title: bitstring(),
@@ -7,7 +7,8 @@ defmodule ExOpenApiUtils.SchemaDefinition do
           properties: list(atom()),
           description: bitstring(),
           tags: list(String.t()),
-          type: atom()
+          type: atom(),
+          nullable: boolean() | nil
         }
   @enforce_keys [:title, :description]
 end

--- a/test/ex_open_api_utils/nullable_schema_test.exs
+++ b/test/ex_open_api_utils/nullable_schema_test.exs
@@ -1,0 +1,41 @@
+defmodule ExOpenApiUtils.NullableSchemaTest do
+  use ExUnit.Case
+  alias ExOpenApiUtilsTest.OpenApiSchema.NullableSchemaRequest
+  alias ExOpenApiUtilsTest.OpenApiSchema.NullableSchemaResponse
+
+  describe "nullable schema support" do
+    test "Request schema has nullable: true" do
+      schema = NullableSchemaRequest.schema()
+      assert schema.nullable == true
+    end
+
+    test "Response schema has nullable: true" do
+      schema = NullableSchemaResponse.schema()
+      assert schema.nullable == true
+    end
+
+    test "Request schema maintains other properties" do
+      schema = NullableSchemaRequest.schema()
+      assert schema.title == "NullableSchemaRequest"
+      assert schema.type == :object
+      assert schema.required == [:name]
+      assert Map.has_key?(schema.properties, :name)
+    end
+
+    test "Response schema maintains other properties" do
+      schema = NullableSchemaResponse.schema()
+      assert schema.title == "NullableSchemaResponse"
+      assert schema.type == :object
+      assert schema.required == [:name]
+      assert Map.has_key?(schema.properties, :name)
+    end
+  end
+
+  describe "schema without nullable option" do
+    test "existing schemas work without nullable (backward compatibility)" do
+      # Use existing TestSchema which doesn't have nullable
+      schema = ExOpenApiUtilsTest.OpenApiSchema.TestSchemaRequest.schema()
+      assert is_nil(schema.nullable) or schema.nullable == false
+    end
+  end
+end

--- a/test/support/nullable_schema_test.ex
+++ b/test/support/nullable_schema_test.ex
@@ -1,0 +1,26 @@
+defmodule ExOpenApiUtilsTest.NullableSchemaTest do
+  use ExOpenApiUtils
+  alias OpenApiSpex.Schema
+
+  open_api_property(
+    key: :name,
+    schema: %Schema{
+      type: :string,
+      description: "Name field"
+    }
+  )
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  schema "nullable_schemas" do
+    field(:name, :string)
+    timestamps()
+  end
+
+  open_api_schema(
+    required: [:name],
+    title: "NullableSchema",
+    description: "A schema that can be null",
+    properties: [:name],
+    nullable: true
+  )
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,5 @@
 # Compile support files before running tests
 Code.require_file("support/test_schema.ex", __DIR__)
+Code.require_file("support/nullable_schema_test.ex", __DIR__)
 
 ExUnit.start()


### PR DESCRIPTION
Add support for nullable at both property and schema levels:
- Add nullable field to SchemaDefinition struct
- Update open_api_schema macro to accept nullable option
- Pass nullable through to Request/Response schema bodies
- Add comprehensive tests for nullable functionality
- Update documentation with nullable usage examples

This enables users to mark entire schemas as nullable using:
  open_api_schema(nullable: true, ...)

And individual properties as nullable using:
  open_api_property(schema: %Schema{nullable: true, ...})

Fixes #10