### PR TITLE
fix: support OpenApiSpex.Reference in is_readOnly?/is_writeOnly?

### DIFF
--- a/lib/ex_open_api_utils.ex
+++ b/lib/ex_open_api_utils.ex
@@ -382,6 +382,10 @@ defmodule ExOpenApiUtils do
     !!readOnly
   end
 
+  def is_readOnly?(%OpenApiSpex.Reference{"$ref": ref}) do
+    String.ends_with?(ref, "Response")
+  end
+
   def is_readOnly?(module) do
     apply(module, :schema, [])
     |> is_readOnly?()
@@ -389,6 +393,10 @@ defmodule ExOpenApiUtils do
 
   def is_writeOnly?(%OpenApiSpex.Schema{writeOnly: writeOnly}) do
     !!writeOnly
+  end
+
+  def is_writeOnly?(%OpenApiSpex.Reference{"$ref": ref}) do
+    String.ends_with?(ref, "Request")
   end
 
   def is_writeOnly?(module) do

--- a/lib/ex_open_api_utils/schema_definition.ex
+++ b/lib/ex_open_api_utils/schema_definition.ex
@@ -1,5 +1,11 @@
 defmodule ExOpenApiUtils.SchemaDefinition do
-  defstruct title: nil, required: [], properties: [], description: "", tags: [], type: :object, nullable: nil
+  defstruct title: nil,
+            required: [],
+            properties: [],
+            description: "",
+            tags: [],
+            type: :object,
+            nullable: nil
 
   @type t :: %__MODULE__{
           title: bitstring(),

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule ExOpenApiUtils.MixProject do
       app: :ex_open_api_utils,
       version: "0.11.0",
       elixir: "~> 1.18",
-      description: "Elixir utilities for OpenAPI 3.2 schema generation from Ecto schemas",
+      description: "Elixir utilities for OpenAPI 3.1 schema generation from Ecto schemas",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       consolidate_protocols: Mix.env() != :test,

--- a/test/ex_open_api_utils_test.exs
+++ b/test/ex_open_api_utils_test.exs
@@ -2,6 +2,42 @@ defmodule ExOpenApiUtilsTest do
   use ExUnit.Case
   doctest ExOpenApiUtils
 
+  alias OpenApiSpex.Reference
+
+  describe "is_readOnly?/1 with Reference" do
+    test "returns true for Reference ending with Response" do
+      ref = %Reference{"$ref": "#/components/schemas/UserResponse"}
+      assert ExOpenApiUtils.is_readOnly?(ref) == true
+    end
+
+    test "returns false for Reference ending with Request" do
+      ref = %Reference{"$ref": "#/components/schemas/UserRequest"}
+      assert ExOpenApiUtils.is_readOnly?(ref) == false
+    end
+
+    test "returns false for Reference with other suffix" do
+      ref = %Reference{"$ref": "#/components/schemas/User"}
+      assert ExOpenApiUtils.is_readOnly?(ref) == false
+    end
+  end
+
+  describe "is_writeOnly?/1 with Reference" do
+    test "returns true for Reference ending with Request" do
+      ref = %Reference{"$ref": "#/components/schemas/UserRequest"}
+      assert ExOpenApiUtils.is_writeOnly?(ref) == true
+    end
+
+    test "returns false for Reference ending with Response" do
+      ref = %Reference{"$ref": "#/components/schemas/UserResponse"}
+      assert ExOpenApiUtils.is_writeOnly?(ref) == false
+    end
+
+    test "returns false for Reference with other suffix" do
+      ref = %Reference{"$ref": "#/components/schemas/User"}
+      assert ExOpenApiUtils.is_writeOnly?(ref) == false
+    end
+  end
+
   describe "x-order property generation" do
     test "Request schema should have x-order extension property" do
       schema = ExOpenApiUtilsTest.OpenApiSchema.TestSchemaRequest.schema()


### PR DESCRIPTION
## Summary

- Add function clauses to handle `OpenApiSpex.Reference` objects in `is_readOnly?/1` and `is_writeOnly?/1`
- Use naming convention heuristic: References ending with `Response` → readOnly, `Request` → writeOnly
- Fix `mix format` issues in `schema_definition.ex`

## Problem

The library crashed when `OpenApiSpex.Reference` objects were used in `open_api_property` calls because `is_readOnly?/1` and `is_writeOnly?/1` only handled `Schema` structs and module atoms.

## Solution

Added pattern matching clauses for `%OpenApiSpex.Reference{}` that use the library's naming convention:
- `#/components/schemas/UserResponse` → treated as readOnly
- `#/components/schemas/UserRequest` → treated as writeOnly

## Test plan

- [x] Added 6 new tests for Reference handling
- [x] All 31 tests pass
- [x] `mix credo --strict` passes

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)