### PR TITLE
fix(deps): make ex_doc a dev-only dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule ExOpenApiUtils.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ex_doc, "~> 0.39.3"},
+      {:ex_doc, "~> 0.39.3", only: :dev, runtime: false},
       {:open_api_spex, "~> 3.22"},
       {:ecto, "~> 3.13"},
       {:inflex, "~> 2.1"},


### PR DESCRIPTION
## Summary

Fixes #18 by making `ex_doc` a dev-only dependency, reducing the dependency footprint in test and production environments.

## Changes

- Updated `ex_doc` dependency declaration to include `only: :dev, runtime: false`
- This follows the same pattern as other dev-only dependencies like `credo`

## Impact

- ✅ All tests pass
- ✅ Reduces dependencies pulled into test and production environments
- ✅ Follows Elixir best practices for optional tooling dependencies
- ✅ Consistent with other dev-only dependencies in the project

## Testing

```bash
mix deps.get
mix test
```

All 37 tests pass successfully.