### PR TITLE
GH-27: persist discriminator propertyName atom into Mapper impl literal pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,21 +2,71 @@ name: CI
 
 on:
   push:
-    branches: [main]
   pull_request:
     branches: [main]
 
+env:
+  ELIXIR_VERSION: "1.18.3"
+  OTP_VERSION: "27.3"
+
 jobs:
-  test:
+  library:
+    name: Library Tests
     runs-on: ubuntu-latest
-    name: Test (OTP ${{ matrix.otp }} / Elixir ${{ matrix.elixir }})
-    strategy:
-      matrix:
-        otp: ["27.3"]
-        elixir: ["1.18.3"]
+    env:
+      MIX_ENV: test
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-library-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-library-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Compile dependencies
+        run: mix deps.compile
+
+      - name: Compile application
+        run: mix compile --warnings-as-errors
+
+      - name: Check formatting
+        run: mix format --check-formatted
+
+      - name: Run Credo
+        run: mix credo --strict
+
+      - name: Run tests
+        run: mix test
+
+      - name: Test Summary
+        if: always()
+        run: |
+          echo "## Library Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "Library suite completed on OTP ${{ env.OTP_VERSION }} / Elixir ${{ env.ELIXIR_VERSION }}." >> $GITHUB_STEP_SUMMARY
+
+  example-app:
+    name: Example App Tests
+    runs-on: ubuntu-latest
+    env:
+      MIX_ENV: test
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/phoenix_ecto_open_api_demo_test
     services:
       postgres:
-        image: postgres:15
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -34,8 +84,8 @@ jobs:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: ${{ matrix.otp }}
-          elixir-version: ${{ matrix.elixir }}
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
 
       - name: Restore dependencies cache
         uses: actions/cache@v4
@@ -45,31 +95,43 @@ jobs:
             _build
             examples/phoenix_ecto_open_api_demo/deps
             examples/phoenix_ecto_open_api_demo/_build
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-          restore-keys: ${{ runner.os }}-mix-
+          key: ${{ runner.os }}-mix-example-${{ hashFiles('mix.lock', 'examples/phoenix_ecto_open_api_demo/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-example-
 
-      - name: Install dependencies
+      - name: Install library dependencies
         run: mix deps.get
-
-      - name: Check formatting
-        run: mix format --check-formatted
-
-      - name: Run tests
-        run: mix test
-
-      - name: Run Credo
-        run: mix credo --strict
 
       - name: Install example dependencies
         working-directory: examples/phoenix_ecto_open_api_demo
         run: mix deps.get
 
+      - name: Compile example dependencies
+        working-directory: examples/phoenix_ecto_open_api_demo
+        run: mix deps.compile
+
+      - name: Compile example application
+        working-directory: examples/phoenix_ecto_open_api_demo
+        run: mix compile --warnings-as-errors
+
+      - name: Check example formatting
+        working-directory: examples/phoenix_ecto_open_api_demo
+        run: mix format --check-formatted
+
+      - name: Create database
+        working-directory: examples/phoenix_ecto_open_api_demo
+        run: mix ecto.create
+
+      - name: Run migrations
+        working-directory: examples/phoenix_ecto_open_api_demo
+        run: mix ecto.migrate
+
       - name: Run example tests
         working-directory: examples/phoenix_ecto_open_api_demo
-        env:
-          MIX_ENV: test
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/phoenix_ecto_open_api_demo_test
+        run: mix test
+
+      - name: Test Summary
+        if: always()
         run: |
-          mix ecto.create
-          mix ecto.migrate
-          mix test
+          echo "## Example App Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "Example suite completed on OTP ${{ env.OTP_VERSION }} / Elixir ${{ env.ELIXIR_VERSION }}." >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 OpenAPI 3.2 schema generation from Ecto schemas for Elixir/Phoenix applications.
 
+[![CI](https://github.com/v3-dot-cash/ex_open_api_utils/actions/workflows/ci.yml/badge.svg)](https://github.com/v3-dot-cash/ex_open_api_utils/actions/workflows/ci.yml)
 [![Module Version](https://img.shields.io/hexpm/v/ex_open_api_utils.svg)](https://hex.pm/packages/ex_open_api_utils)
 [![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/ex_open_api_utils/)
 [![Total Download](https://img.shields.io/hexpm/dt/ex_open_api_utils.svg)](https://hex.pm/packages/ex_open_api_utils)

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/audit_context.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/audit_context.ex
@@ -1,0 +1,19 @@
+defmodule PhoenixEctoOpenApiDemo.AuditContext do
+  @moduledoc """
+  Context module for polymorphic audit events.
+
+  Deliberately minimal (no `list_/update_/delete_` helpers) — this context
+  exists as a paranoia fixture for the GH-27 bytecode persistence
+  regression lock, not as a full CRUD demo.
+  """
+  alias PhoenixEctoOpenApiDemo.AuditContext.AuditEvent
+  alias PhoenixEctoOpenApiDemo.Repo
+
+  def get_audit_event!(id), do: Repo.get!(AuditEvent, id)
+
+  def create_audit_event(attrs) do
+    %AuditEvent{}
+    |> AuditEvent.changeset(attrs)
+    |> Repo.insert()
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/audit_context/audit_event.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/audit_context/audit_event.ex
@@ -1,0 +1,120 @@
+defmodule PhoenixEctoOpenApiDemo.AuditContext.AuditEvent do
+  @moduledoc """
+  Parent schema for an audit event with a polymorphic `:payload`.
+
+  This fixture exists to cover two scenarios the notification example does
+  not:
+
+    1. **Context-only surface.** There is no controller wired for audit
+       events — the library consumer interacts only with the Ecto context.
+       Proves `polymorphic_embed_discriminator/1` does not require a Phoenix
+       controller boundary to function.
+    2. **Unique discriminator propertyName.** The wire discriminator is
+       `"audit_kind"`, which is deliberately chosen so that `:audit_kind`
+       does not appear as an atom literal anywhere else in the project.
+       Under the GH-27 bug, the atom would not exist in the runtime atom
+       table and `OpenApiSpex.Cast.Discriminator` would crash. The fix
+       stores the atom as a bytecode literal inside the derived Mapper
+       impl so it survives into a freshly-started BEAM.
+
+  Also exercises the cross-name bridge: the Ecto-side `type_field_name`
+  is `:__audit_type__`, distinct from the wire-side `"audit_kind"`.
+  """
+  use ExOpenApiUtils
+  alias OpenApiSpex.Discriminator
+
+  alias PhoenixEctoOpenApiDemo.AuditContext.DataExportEvent
+  alias PhoenixEctoOpenApiDemo.AuditContext.UserLoginEvent
+
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.DataExportEventRequest
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.DataExportEventResponse
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.UserLoginEventRequest
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.UserLoginEventResponse
+
+  import PolymorphicEmbed
+
+  Code.ensure_compiled!(UserLoginEvent)
+  Code.ensure_compiled!(DataExportEvent)
+
+  open_api_property(
+    key: :id,
+    schema: %Schema{
+      type: :string,
+      format: :uuid,
+      example: "851b18d7-0c88-4095-9969-cbe385926420",
+      readOnly: true
+    }
+  )
+
+  open_api_property(
+    key: :actor,
+    schema: %Schema{type: :string, example: "api-token-42"}
+  )
+
+  open_api_property(
+    key: :payload,
+    schema: %Schema{
+      type: :object,
+      writeOnly: true,
+      oneOf: [UserLoginEventRequest, DataExportEventRequest],
+      discriminator: %Discriminator{
+        propertyName: "audit_kind",
+        mapping: %{
+          "user_login" => UserLoginEventRequest,
+          "data_export" => DataExportEventRequest
+        }
+      }
+    }
+  )
+
+  open_api_property(
+    key: :payload,
+    schema: %Schema{
+      type: :object,
+      readOnly: true,
+      oneOf: [UserLoginEventResponse, DataExportEventResponse],
+      discriminator: %Discriminator{
+        propertyName: "audit_kind",
+        mapping: %{
+          "user_login" => UserLoginEventResponse,
+          "data_export" => DataExportEventResponse
+        }
+      }
+    }
+  )
+
+  polymorphic_embed_discriminator(key: :payload, type_field_name: :__audit_type__)
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "audit_events" do
+    field :actor, :string
+
+    polymorphic_embeds_one(:payload,
+      types: [
+        user_login: UserLoginEvent,
+        data_export: DataExportEvent
+      ],
+      type_field_name: :__audit_type__,
+      on_type_not_found: :raise,
+      on_replace: :update
+    )
+
+    timestamps()
+  end
+
+  open_api_schema(
+    title: "AuditEvent",
+    description: "An audit event with a polymorphic payload",
+    required: [:actor, :payload],
+    properties: [:id, :actor, :payload],
+    tags: ["Audit"]
+  )
+
+  def changeset(audit_event, attrs) do
+    audit_event
+    |> cast(attrs, [:actor])
+    |> validate_required([:actor])
+    |> cast_polymorphic_embed(:payload, required: true)
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/audit_context/data_export_event.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/audit_context/data_export_event.ex
@@ -1,0 +1,42 @@
+defmodule PhoenixEctoOpenApiDemo.AuditContext.DataExportEvent do
+  @moduledoc """
+  Data-export variant for `PhoenixEctoOpenApiDemo.AuditContext.AuditEvent`.
+  """
+  use ExOpenApiUtils
+
+  open_api_property(
+    schema: %Schema{
+      type: :string,
+      description: "The resource that was exported",
+      example: "users"
+    },
+    key: :resource
+  )
+
+  open_api_property(
+    schema: %Schema{
+      type: :integer,
+      description: "Number of rows exported",
+      example: 42
+    },
+    key: :row_count
+  )
+
+  embedded_schema do
+    field :resource, :string
+    field :row_count, :integer
+  end
+
+  open_api_schema(
+    title: "DataExportEvent",
+    description: "An audit record emitted when data is exported",
+    required: [:resource, :row_count],
+    properties: [:resource, :row_count]
+  )
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:resource, :row_count])
+    |> validate_required([:resource, :row_count])
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/audit_context/user_login_event.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/audit_context/user_login_event.ex
@@ -1,0 +1,42 @@
+defmodule PhoenixEctoOpenApiDemo.AuditContext.UserLoginEvent do
+  @moduledoc """
+  User-login variant for `PhoenixEctoOpenApiDemo.AuditContext.AuditEvent`.
+  """
+  use ExOpenApiUtils
+
+  open_api_property(
+    schema: %Schema{
+      type: :string,
+      description: "The authenticated user's identifier",
+      example: "u_123"
+    },
+    key: :user_id
+  )
+
+  open_api_property(
+    schema: %Schema{
+      type: :string,
+      description: "Source IP address of the login",
+      example: "10.0.0.1"
+    },
+    key: :ip_address
+  )
+
+  embedded_schema do
+    field :user_id, :string
+    field :ip_address, :string
+  end
+
+  open_api_schema(
+    title: "UserLoginEvent",
+    description: "An audit record emitted on user login",
+    required: [:user_id, :ip_address],
+    properties: [:user_id, :ip_address]
+  )
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:user_id, :ip_address])
+    |> validate_required([:user_id, :ip_address])
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/business_context/business.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/business_context/business.ex
@@ -1,6 +1,6 @@
 defmodule PhoenixEctoOpenApiDemo.BusinessContext.Business do
   use ExOpenApiUtils
-  alias PhoenixEctoOpenApiDemo.TenantContext.Business
+  alias PhoenixEctoOpenApiDemo.TenantContext.Tenant
 
   @primary_key {:id, :binary_id, autogenerate: true}
   open_api_property(

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo_web/api_spec.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo_web/api_spec.ex
@@ -6,8 +6,7 @@ defmodule PhoenixEctoOpenApiDemoWeb.ApiSpec do
     OpenApi,
     Paths,
     SecurityScheme,
-    Server,
-    Tag
+    Server
   }
 
   @behaviour OpenApi

--- a/examples/phoenix_ecto_open_api_demo/priv/repo/migrations/20260411000000_create_audit_events.exs
+++ b/examples/phoenix_ecto_open_api_demo/priv/repo/migrations/20260411000000_create_audit_events.exs
@@ -1,0 +1,13 @@
+defmodule PhoenixEctoOpenApiDemo.Repo.Migrations.CreateAuditEvents do
+  use Ecto.Migration
+
+  def change do
+    create table(:audit_events, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :actor, :string, null: false
+      add :payload, :map, null: false
+
+      timestamps()
+    end
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/test/phoenix_ecto_open_api_demo/audit_context_test.exs
+++ b/examples/phoenix_ecto_open_api_demo/test/phoenix_ecto_open_api_demo/audit_context_test.exs
@@ -1,0 +1,132 @@
+defmodule PhoenixEctoOpenApiDemo.AuditContextTest do
+  @moduledoc """
+  Context-only paranoia coverage for `polymorphic_embed_discriminator/1`.
+
+  The audit fixture exists specifically to lock the GH-27 bytecode
+  persistence guarantee in a scenario that has no Phoenix controller
+  wrapping it — the library consumer touches only the Ecto context.
+
+  The `:audit_kind` wire discriminator is chosen so that it does not
+  appear as an atom literal anywhere else in the project. Under the
+  GH-27 bug, the only place the atom could exist is the runtime atom
+  table at compile time; after the fix, it is baked into the derived
+  Mapper impl module's `.beam` atom chunk.
+  """
+  use PhoenixEctoOpenApiDemo.DataCase
+
+  import PhoenixEctoOpenApiDemo.AuditContextFixtures
+
+  alias PhoenixEctoOpenApiDemo.AuditContext
+  alias PhoenixEctoOpenApiDemo.AuditContext.AuditEvent
+  alias PhoenixEctoOpenApiDemo.AuditContext.DataExportEvent
+  alias PhoenixEctoOpenApiDemo.AuditContext.UserLoginEvent
+
+  describe "create_audit_event/1" do
+    test "round-trips a user-login payload through polymorphic_embed" do
+      event = user_login_audit_fixture()
+      reloaded = AuditContext.get_audit_event!(event.id)
+
+      assert %AuditEvent{
+               actor: "api-token-42",
+               payload: %UserLoginEvent{
+                 user_id: "u_123",
+                 ip_address: "10.0.0.1"
+               }
+             } = reloaded
+    end
+
+    test "round-trips a data-export payload through polymorphic_embed" do
+      event = data_export_audit_fixture()
+      reloaded = AuditContext.get_audit_event!(event.id)
+
+      assert %AuditEvent{
+               actor: "api-token-42",
+               payload: %DataExportEvent{
+                 resource: "users",
+                 row_count: 42
+               }
+             } = reloaded
+    end
+  end
+
+  describe "Mapper.to_map/1 outbound serialization" do
+    test "emits wire key \"audit_kind\" for a user-login payload" do
+      event = user_login_audit_fixture()
+      map = ExOpenApiUtils.Mapper.to_map(event)
+
+      assert map["actor"] == "api-token-42"
+      assert map["payload"]["audit_kind"] == "user_login"
+      assert map["payload"]["user_id"] == "u_123"
+      assert map["payload"]["ip_address"] == "10.0.0.1"
+    end
+
+    test "emits wire key \"audit_kind\" for a data-export payload" do
+      event = data_export_audit_fixture()
+      map = ExOpenApiUtils.Mapper.to_map(event)
+
+      assert map["payload"]["audit_kind"] == "data_export"
+      assert map["payload"]["resource"] == "users"
+      assert map["payload"]["row_count"] == 42
+    end
+  end
+
+  describe "discriminator atom persistence (GH-27 regression lock, context-only)" do
+    # Bytecode-level assertion: walk the `abstract_code` chunk of the
+    # compiled Mapper impl's .beam and verify that `:audit_kind` is
+    # present as an `{:atom, line, name}` literal.
+    #
+    # A check against the `:atoms` chunk (`AtU8`) would miss atoms that
+    # live only in the literal pool (`LitT`), which is where
+    # `Macro.escape`-d compile-time maps get stored.  The BEAM loader
+    # materializes those atoms at module-load time, so the abstract_code
+    # walk is the right way to verify the atom will survive into any
+    # freshly started BEAM.
+    #
+    # Both Request and Response Mapper impls are covered because each
+    # receives its own `Protocol.derive` call inside `__before_compile__`.
+
+    defp collect_atoms({:atom, _line, name}, acc) when is_atom(name) do
+      MapSet.put(acc, name)
+    end
+
+    defp collect_atoms(tuple, acc) when is_tuple(tuple) do
+      tuple
+      |> Tuple.to_list()
+      |> Enum.reduce(acc, &collect_atoms/2)
+    end
+
+    defp collect_atoms(list, acc) when is_list(list) do
+      Enum.reduce(list, acc, &collect_atoms/2)
+    end
+
+    defp collect_atoms(_, acc), do: acc
+
+    defp literal_atoms_in(module) do
+      beam_path = :code.which(module)
+      refute beam_path in [:non_existing, :preloaded, :cover_compiled]
+
+      {:ok, {_, [{:abstract_code, {:raw_abstract_v1, forms}}]}} =
+        :beam_lib.chunks(beam_path, [:abstract_code])
+
+      collect_atoms(forms, MapSet.new())
+    end
+
+    test "AuditEventRequest Mapper impl .beam contains :audit_kind" do
+      atoms =
+        literal_atoms_in(
+          ExOpenApiUtils.Mapper.PhoenixEctoOpenApiDemo.OpenApiSchema.AuditEventRequest
+        )
+
+      assert :audit_kind in atoms
+    end
+
+    test "AuditEventResponse Mapper impl .beam contains :audit_kind" do
+      atoms =
+        literal_atoms_in(
+          ExOpenApiUtils.Mapper.PhoenixEctoOpenApiDemo.OpenApiSchema.AuditEventResponse
+        )
+
+      assert :audit_kind in atoms
+    end
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/test/phoenix_ecto_open_api_demo_web/controllers/notification_controller_test.exs
+++ b/examples/phoenix_ecto_open_api_demo/test/phoenix_ecto_open_api_demo_web/controllers/notification_controller_test.exs
@@ -528,4 +528,66 @@ defmodule PhoenixEctoOpenApiDemoWeb.NotificationControllerTest do
       end
     end
   end
+
+  describe "discriminator atom persistence (GH-27 regression lock, Phoenix flow)" do
+    # Bytecode-level assertion: walk the `abstract_code` chunk of the
+    # compiled Mapper impl's .beam and verify that `:object_type` is
+    # present as an `{:atom, line, name}` literal.  This is the canonical
+    # pre-optimization AST emitted by the Elixir compiler — if the atom
+    # is anywhere in the compiled module, it will show up here.
+    #
+    # A simple check against the `:atoms` chunk (`AtU8`) would miss atoms
+    # that live only in the literal pool (`LitT`), which is where
+    # `Macro.escape`-d compile-time maps end up.  The BEAM loader
+    # materializes those atoms at module-load time regardless of AtU8
+    # membership, so the abstract_code walk is both broader and stricter.
+    #
+    # The example app compiles its test support to real .beam files via
+    # `elixirc_paths(:test) -> ["lib", "test/support"]`, so `:code.which/1`
+    # returns an on-disk path and `:beam_lib.chunks/2` reads it directly.
+
+    defp collect_atoms({:atom, _line, name}, acc) when is_atom(name) do
+      MapSet.put(acc, name)
+    end
+
+    defp collect_atoms(tuple, acc) when is_tuple(tuple) do
+      tuple
+      |> Tuple.to_list()
+      |> Enum.reduce(acc, &collect_atoms/2)
+    end
+
+    defp collect_atoms(list, acc) when is_list(list) do
+      Enum.reduce(list, acc, &collect_atoms/2)
+    end
+
+    defp collect_atoms(_, acc), do: acc
+
+    defp literal_atoms_in(module) do
+      beam_path = :code.which(module)
+      refute beam_path in [:non_existing, :preloaded, :cover_compiled]
+
+      {:ok, {_, [{:abstract_code, {:raw_abstract_v1, forms}}]}} =
+        :beam_lib.chunks(beam_path, [:abstract_code])
+
+      collect_atoms(forms, MapSet.new())
+    end
+
+    test "NotificationRequest Mapper impl .beam contains :object_type" do
+      atoms =
+        literal_atoms_in(
+          ExOpenApiUtils.Mapper.PhoenixEctoOpenApiDemo.OpenApiSchema.NotificationRequest
+        )
+
+      assert :object_type in atoms
+    end
+
+    test "NotificationResponse Mapper impl .beam contains :object_type" do
+      atoms =
+        literal_atoms_in(
+          ExOpenApiUtils.Mapper.PhoenixEctoOpenApiDemo.OpenApiSchema.NotificationResponse
+        )
+
+      assert :object_type in atoms
+    end
+  end
 end

--- a/examples/phoenix_ecto_open_api_demo/test/support/fixtures/audit_context_fixtures.ex
+++ b/examples/phoenix_ecto_open_api_demo/test/support/fixtures/audit_context_fixtures.ex
@@ -1,0 +1,46 @@
+defmodule PhoenixEctoOpenApiDemo.AuditContextFixtures do
+  @moduledoc """
+  Test helpers for creating `PhoenixEctoOpenApiDemo.AuditContext` entities.
+
+  Fixture attribute maps use string keys throughout so that the test-file
+  bytecode never accidentally references the wire discriminator atom as a
+  literal. The bytecode persistence regression lock depends on the
+  library's Mapper impl being the only compiled artifact that carries
+  `:audit_kind` — an accidental atom literal elsewhere would mask the bug
+  by rescuing the atom into the runtime atom table.
+  """
+
+  alias PhoenixEctoOpenApiDemo.AuditContext
+
+  @doc "Creates an audit event with a user-login payload."
+  def user_login_audit_fixture(attrs \\ %{}) do
+    attrs =
+      Enum.into(attrs, %{
+        "actor" => "api-token-42",
+        "payload" => %{
+          "__audit_type__" => "user_login",
+          "user_id" => "u_123",
+          "ip_address" => "10.0.0.1"
+        }
+      })
+
+    {:ok, audit_event} = AuditContext.create_audit_event(attrs)
+    audit_event
+  end
+
+  @doc "Creates an audit event with a data-export payload."
+  def data_export_audit_fixture(attrs \\ %{}) do
+    attrs =
+      Enum.into(attrs, %{
+        "actor" => "api-token-42",
+        "payload" => %{
+          "__audit_type__" => "data_export",
+          "resource" => "users",
+          "row_count" => 42
+        }
+      })
+
+    {:ok, audit_event} = AuditContext.create_audit_event(attrs)
+    audit_event
+  end
+end

--- a/lib/ex_open_api_utils.ex
+++ b/lib/ex_open_api_utils.ex
@@ -501,12 +501,6 @@ defmodule ExOpenApiUtils do
     discriminator_string =
       fetch_matching_discriminator_property_name!(key, write_prop, read_prop)
 
-    # Ensure the atom form of the discriminator property name exists so
-    # OpenApiSpex.Cast.Discriminator's `String.to_existing_atom/1` call
-    # at cast time does not blow up. This is a deliberate, single-site
-    # atom creation keyed off a value the user declared in their schema.
-    _ = String.to_atom(discriminator_string)
-
     check_oneof_matches_mapping!(key, :writeOnly, write_prop.schema)
     check_oneof_matches_mapping!(key, :readOnly, read_prop.schema)
 
@@ -536,9 +530,23 @@ defmodule ExOpenApiUtils do
       end)
       |> Map.new()
 
+    # Store the atom form of the discriminator propertyName in the
+    # returned map. This map flows through
+    # `Protocol.derive(..., polymorphic_variants: ...)` which passes it
+    # to `ExOpenApiUtils.Mapper.__deriving__/3`, where `Macro.escape/1`
+    # pins the whole map as a literal inside the generated Mapper impl's
+    # `to_map/1` body. Elixir's compiler stashes that literal in the
+    # module's LitT (literal pool) chunk, and the BEAM loader
+    # materialises every atom inside the literal pool at module-load
+    # time — so `:object_type` (or whatever the user declared) is
+    # present in the runtime atom table the moment the compiled `.beam`
+    # file is loaded, even in a freshly-started BEAM that has never run
+    # the library's compile-time `__before_compile__` hook.
+    # See GH-27 for the bug this fixes.
     %{
       variant_map: variant_map,
       discriminator_string: discriminator_string,
+      discriminator_atom: String.to_atom(discriminator_string),
       type_field_atom: type_field_name
     }
   end

--- a/lib/ex_open_api_utils/property.ex
+++ b/lib/ex_open_api_utils/property.ex
@@ -1,4 +1,5 @@
 defmodule ExOpenApiUtils.Property do
+  @enforce_keys [:key, :schema]
   defstruct schema: nil, key: nil, source: nil
 
   @type t :: %__MODULE__{
@@ -6,5 +7,4 @@ defmodule ExOpenApiUtils.Property do
           key: atom(),
           source: atom()
         }
-  @enforce_keys [:key, :schema]
 end

--- a/lib/ex_open_api_utils/schema_definition.ex
+++ b/lib/ex_open_api_utils/schema_definition.ex
@@ -1,4 +1,5 @@
 defmodule ExOpenApiUtils.SchemaDefinition do
+  @enforce_keys [:title, :description]
   defstruct title: nil,
             required: [],
             properties: [],
@@ -16,5 +17,4 @@ defmodule ExOpenApiUtils.SchemaDefinition do
           type: atom(),
           nullable: boolean() | nil
         }
-  @enforce_keys [:title, :description]
 end

--- a/test/ex_open_api_utils/polymorphic_discriminator_test.exs
+++ b/test/ex_open_api_utils/polymorphic_discriminator_test.exs
@@ -820,4 +820,84 @@ defmodule ExOpenApiUtils.PolymorphicDiscriminatorTest do
       end
     end
   end
+
+  describe "discriminator propertyName atom persistence (GH-27 regression lock)" do
+    # Bytecode-level assertion: walk the `abstract_code` chunk of a compiled
+    # Mapper impl's BEAM binary and check that the discriminator
+    # propertyName atom is present as an `{:atom, line, name}` literal.
+    #
+    # A runtime `Cast.cast/3` smoke test cannot catch this bug because
+    # `mix test` compiles and runs in the same BEAM, so any atom created
+    # via compile-time `String.to_atom/1` stays hot in the runtime atom
+    # table.  Nor can a check against the `:atoms` chunk (`AtU8`) — atoms
+    # that live only inside the literal pool (`LitT`) are created by the
+    # BEAM loader when the literal pool is deserialized, and they do not
+    # necessarily appear in `AtU8`.  The `abstract_code` chunk is the
+    # canonical pre-optimization AST the Elixir compiler emits and
+    # contains every literal atom the compiled module will materialize at
+    # load time.
+    #
+    # Test support files are loaded via `Code.compile_file/1` in
+    # `test_helper.exs` — the resulting binaries are stashed in
+    # `:persistent_term` so these tests can read them without the file
+    # being written to disk.
+
+    defp literal_atoms_in(module) do
+      bin = ExOpenApiUtilsTest.CompiledFixtures.beam_binary(module)
+      assert is_binary(bin), "no stashed BEAM binary for #{inspect(module)}"
+
+      {:ok, {_, [{:abstract_code, {:raw_abstract_v1, forms}}]}} =
+        :beam_lib.chunks(bin, [:abstract_code])
+
+      collect_atoms(forms, MapSet.new())
+    end
+
+    defp collect_atoms({:atom, _line, name}, acc) when is_atom(name) do
+      MapSet.put(acc, name)
+    end
+
+    defp collect_atoms(tuple, acc) when is_tuple(tuple) do
+      tuple
+      |> Tuple.to_list()
+      |> Enum.reduce(acc, &collect_atoms/2)
+    end
+
+    defp collect_atoms(list, acc) when is_list(list) do
+      Enum.reduce(list, acc, &collect_atoms/2)
+    end
+
+    defp collect_atoms(_, acc), do: acc
+
+    test "NotificationRequest Mapper impl .beam contains :object_type" do
+      atoms =
+        literal_atoms_in(
+          ExOpenApiUtils.Mapper.ExOpenApiUtilsTest.OpenApiSchema.NotificationRequest
+        )
+
+      assert :object_type in atoms
+    end
+
+    test "NotificationResponse Mapper impl .beam contains :object_type" do
+      atoms =
+        literal_atoms_in(
+          ExOpenApiUtils.Mapper.ExOpenApiUtilsTest.OpenApiSchema.NotificationResponse
+        )
+
+      assert :object_type in atoms
+    end
+
+    test "AnalyticsRequest Mapper impl .beam contains :kind (cross-name fixture)" do
+      atoms =
+        literal_atoms_in(ExOpenApiUtils.Mapper.ExOpenApiUtilsTest.OpenApiSchema.AnalyticsRequest)
+
+      assert :kind in atoms
+    end
+
+    test "AnalyticsResponse Mapper impl .beam contains :kind" do
+      atoms =
+        literal_atoms_in(ExOpenApiUtils.Mapper.ExOpenApiUtilsTest.OpenApiSchema.AnalyticsResponse)
+
+      assert :kind in atoms
+    end
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,16 +2,51 @@
 Code.require_file("support/test_schema.ex", __DIR__)
 Code.require_file("support/nullable_schema_test.ex", __DIR__)
 
+defmodule ExOpenApiUtilsTest.CompiledFixtures do
+  @moduledoc false
+  # Compiles a fixture file and stashes each resulting module's compiled
+  # `.beam` binary in `:persistent_term` so that regression tests can read
+  # the atom chunk via `:beam_lib.chunks/2` without the file ever landing
+  # on disk. Used by the GH-27 discriminator atom persistence test.
+  def stash(relative_path) do
+    relative_path
+    |> Path.expand(File.cwd!())
+    |> Code.compile_file()
+    |> Enum.each(fn {mod, bin} ->
+      :persistent_term.put({__MODULE__, mod}, bin)
+    end)
+  end
+
+  def beam_binary(module) do
+    :persistent_term.get({__MODULE__, module}, nil)
+  end
+end
+
 # Polymorphic discriminator fixtures: variants must load before parents,
 # because parents reference the variants' generated OpenApiSchema sub-modules
-# inside the discriminator's oneOf at macro-expansion time.
-Code.require_file("support/polymorphic_discriminator/email_channel.ex", __DIR__)
-Code.require_file("support/polymorphic_discriminator/sms_channel.ex", __DIR__)
-Code.require_file("support/polymorphic_discriminator/webhook_channel.ex", __DIR__)
-Code.require_file("support/polymorphic_discriminator/notification.ex", __DIR__)
+# inside the discriminator's oneOf at macro-expansion time. We compile via
+# the `stash/1` helper so the resulting binaries — including each module's
+# auto-derived Mapper impl — are retrievable by regression tests.
+ExOpenApiUtilsTest.CompiledFixtures.stash(
+  "test/support/polymorphic_discriminator/email_channel.ex"
+)
 
-Code.require_file("support/polymorphic_discriminator/click_event.ex", __DIR__)
-Code.require_file("support/polymorphic_discriminator/pageview_event.ex", __DIR__)
-Code.require_file("support/polymorphic_discriminator/analytics.ex", __DIR__)
+ExOpenApiUtilsTest.CompiledFixtures.stash("test/support/polymorphic_discriminator/sms_channel.ex")
+
+ExOpenApiUtilsTest.CompiledFixtures.stash(
+  "test/support/polymorphic_discriminator/webhook_channel.ex"
+)
+
+ExOpenApiUtilsTest.CompiledFixtures.stash(
+  "test/support/polymorphic_discriminator/notification.ex"
+)
+
+ExOpenApiUtilsTest.CompiledFixtures.stash("test/support/polymorphic_discriminator/click_event.ex")
+
+ExOpenApiUtilsTest.CompiledFixtures.stash(
+  "test/support/polymorphic_discriminator/pageview_event.ex"
+)
+
+ExOpenApiUtilsTest.CompiledFixtures.stash("test/support/polymorphic_discriminator/analytics.ex")
 
 ExUnit.start()


### PR DESCRIPTION
Closes #27.

## Summary

`polymorphic_embed_discriminator/1` was relying on a discarded `_ = String.to_atom(discriminator_string)` call to seed the BEAM atom table at compile time. The atom ended up in the compiling VM's runtime atom table but was never referenced by any bytecode, so the `.beam` files shipped to production never carried it in any form. When a freshly-started BEAM loaded those files, `OpenApiSpex.Cast.Discriminator` called `String.to_existing_atom(propertyName)` and crashed with `ArgumentError: not an already existing atom` on the first cast of any polymorphic request.

## The fix

Store the atom inside the `polymorphic_variants` map that already flows through `Protocol.derive(ExOpenApiUtils.Mapper, ...)`. `Mapper.__deriving__/3` escapes that map into the generated impl's `to_map/1` body via `Macro.escape/1`, which the Elixir compiler stashes as a `LitT` (literal pool) entry in the Mapper impl's `.beam`. The BEAM loader materialises every atom inside the literal pool at module-load time, so the discriminator propertyName exists in the runtime atom table the moment the compiled `.beam` is loaded — regardless of whether the loading BEAM ever ran `__before_compile__`.

The change to ``lib/ex_open_api_utils.ex`` is three lines: delete the discarded ``String.to_atom/1`` call and add ``discriminator_atom: String.to_atom(discriminator_string)`` to the returned variant entry map. ``Mapper.Polymorphic.inject/5`` needs no change because its existing pattern match is a partial match that tolerates additional keys.

## Why the earlier PR missed this

Two independent reasons both rooted in BEAM atom-table semantics:

1. **`mix test` compiles and runs in the same OS process.** The atom created via the discarded `String.to_atom/1` at compile time stayed hot in the runtime atom table for the duration of the test run. The test suite could not distinguish "atom in bytecode" from "atom created at compile time and still hot in this VM" — a cold-started BEAM loading just the compiled `.beam` files was never actually attempted.

2. **The example app's notification controller test contained an accidental rescue.** The `@email_attrs %{channel: %{object_type: "email", ...}}` module attribute compiled `:object_type` into the test module's own `.beam` atom chunk. When the test module loaded, it forced `:object_type` into the runtime atom table — rescuing the bug invisibly. A propertyName that did not happen to appear as an atom literal anywhere else in the project would have crashed the example app's first cast call, even in `mix test`.

## Regression locks added

Every new test walks the compiled Mapper impl's `abstract_code` chunk via `:beam_lib.chunks(beam, [:abstract_code])` and asserts the discriminator propertyName appears as an `{:atom, line, name}` literal. The `abstract_code` chunk sees atoms that live only in the literal pool, which a check against `:atoms` (the `AtU8` chunk) would miss.

- **Library** (`test/ex_open_api_utils/polymorphic_discriminator_test.exs`): four bytecode assertions against `NotificationRequest` / `NotificationResponse` (same-name wire-vs-Ecto) and `AnalyticsRequest` / `AnalyticsResponse` (cross-name where wire is `"kind"` and Ecto `type_field_name` is `:event_type`). Library fixtures load in-memory via `Code.require_file` so `:code.which/1` would return `:non_existing`; a new `CompiledFixtures` stash helper in `test_helper.exs` wraps `Code.compile_file/1` to retain the binaries in `:persistent_term` for inspection.

- **Example app, Phoenix flow** (`test/phoenix_ecto_open_api_demo_web/controllers/notification_controller_test.exs`): two assertions against the example's own `NotificationRequest` / `NotificationResponse` Mapper impls for `:object_type`. The example app compiles test support to real `.beam` files on disk via `elixirc_paths(:test)` so `:code.which/1` returns the path directly.

- **Example app, paranoia fixture, context-only** (`test/phoenix_ecto_open_api_demo/audit_context_test.exs`): a new `AuditContext` with `UserLoginEvent` and `DataExportEvent` variants, parent `AuditEvent`, migration, context module, and fixtures. No Phoenix controller — proves the fix works for schemas that are never exposed over HTTP. Uses the deliberately unique discriminator propertyName `"audit_kind"` (grep-confirmed unused elsewhere in the project) and a cross-name bridge: wire is `"audit_kind"`, Ecto's `type_field_name` is `:__audit_type__`. Fixture attribute maps use string keys throughout so no test-module bytecode accidentally references `:audit_kind` as a literal — if anything were going to rescue the atom into the runtime table, it would have to be the library's own compiled Mapper impl and nothing else. Six tests: two Ecto round-trip sanity checks, two Mapper.to_map outbound serialisation checks, two bytecode persistence checks (Request + Response).

All eight new regression tests were added BEFORE the fix, run against the broken code, and confirmed to fail at the `abstract_code` level. They flip to green exactly when the fix is applied.

## Cold-BEAM sanity check

Verified the fix directly by loading the compiled `AuditEventRequest` Mapper impl `.beam` into a fresh `elixir` subprocess (no library compile step, no prior context) and calling `:erlang.binary_to_existing_atom("audit_kind", :utf8)`. Before `:code.load_binary`: the atom does not exist. After: the atom exists — materialised from the literal pool by the BEAM loader. `:object_type` stays absent because `NotificationRequest` was not loaded, proving the test is not leaking atoms from unrelated modules.

## CI changes

`.github/workflows/ci.yml` is split into two parallel jobs:

- **`library`** — no database, runs `mix deps.get`, `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`, `mix test`.
- **`example-app`** — postgres 17 service, runs library deps, example deps, example compile, example format, `mix ecto.create`, `mix ecto.migrate`, `mix test`.

Both jobs trigger on every push and on pull requests to `main`, run in parallel (no `needs:` dependency between them), and share the same Elixir/OTP versions via workflow-level `env:`.

## Test plan

- [x] Library: `mix test` — 86 tests, 0 failures (82 original + 4 new bytecode locks).
- [x] Library: `mix format --check-formatted` — clean.
- [x] Library: `mix credo --strict` — clean.
- [x] Example app: `mix ecto.create && mix ecto.migrate && mix test` — 72 tests, 0 failures (64 original + 8 new: 2 notification bytecode + 2 audit round-trip + 2 audit Mapper + 2 audit bytecode).
- [x] Example app: `mix format --check-formatted` — clean.
- [x] Cold-BEAM: subprocess `elixir` + `:code.load_binary` proves the atom is materialised at load time without any compile-step assistance.
- [x] CI: push to branch and confirm both `library` and `example-app` jobs run in parallel and pass.

## Semver

Patch-level fix. release-please will bump 0.13.0 → 0.13.1 on merge.