### PR TITLE
test: drop redundant read_write_scope: :read from Cast.cast/4 sites

### DIFF
--- a/examples/phoenix_ecto_open_api_demo/test/phoenix_ecto_open_api_demo_web/controllers/notification_controller_test.exs
+++ b/examples/phoenix_ecto_open_api_demo/test/phoenix_ecto_open_api_demo_web/controllers/notification_controller_test.exs
@@ -12,10 +12,9 @@ defmodule PhoenixEctoOpenApiDemoWeb.NotificationControllerTest do
     2. Takes the raw JSON response body and feeds it back through
        `OpenApiSpex.Cast.cast/4` against the resolved
        `NotificationResponse` schema in `@api_spec.components.schemas`.
-       The call uses `read_write_scope: :read` so required `writeOnly`
-       fields are skipped on the response side. On success it returns a
-       real `%NotificationResponseSchema{}` struct whose `:channel` is the
-       correct variant struct (`%NotificationEmailResponse{}`, `%NotificationSmsResponse{}`, or
+       On success it returns a real `%NotificationResponseSchema{}` struct
+       whose `:channel` is the correct variant struct
+       (`%NotificationEmailResponse{}`, `%NotificationSmsResponse{}`, or
        `%NotificationWebhookResponse{}`) dispatched from the oneOf.
 
     3. Does a full deep pattern-match on the cast struct — every variant
@@ -111,7 +110,7 @@ defmodule PhoenixEctoOpenApiDemoWeb.NotificationControllerTest do
       cast_items =
         Enum.map(body, fn item ->
           assert {:ok, cast} =
-                   Cast.cast(notification_schema, item, schemas, read_write_scope: :read)
+                   Cast.cast(notification_schema, item, schemas)
 
           cast
         end)
@@ -174,7 +173,7 @@ defmodule PhoenixEctoOpenApiDemoWeb.NotificationControllerTest do
       schemas = @api_spec.components.schemas
       schema = Map.fetch!(schemas, "NotificationResponse")
 
-      assert {:ok, cast} = Cast.cast(schema, body, schemas, read_write_scope: :read)
+      assert {:ok, cast} = Cast.cast(schema, body, schemas)
 
       # Deep pattern match on the cast struct — every variant field checked
       # by name, variant struct asserted, nothing from other variants
@@ -235,7 +234,7 @@ defmodule PhoenixEctoOpenApiDemoWeb.NotificationControllerTest do
       schemas = @api_spec.components.schemas
       schema = Map.fetch!(schemas, "NotificationResponse")
 
-      assert {:ok, cast} = Cast.cast(schema, body, schemas, read_write_scope: :read)
+      assert {:ok, cast} = Cast.cast(schema, body, schemas)
 
       assert %NotificationResponseSchema{
                id: id,
@@ -283,7 +282,7 @@ defmodule PhoenixEctoOpenApiDemoWeb.NotificationControllerTest do
       schemas = @api_spec.components.schemas
       schema = Map.fetch!(schemas, "NotificationResponse")
 
-      assert {:ok, cast} = Cast.cast(schema, body, schemas, read_write_scope: :read)
+      assert {:ok, cast} = Cast.cast(schema, body, schemas)
 
       assert %NotificationResponseSchema{
                id: id,
@@ -333,7 +332,7 @@ defmodule PhoenixEctoOpenApiDemoWeb.NotificationControllerTest do
 
       schemas = @api_spec.components.schemas
       schema = Map.fetch!(schemas, "NotificationResponse")
-      assert {:ok, cast} = Cast.cast(schema, body, schemas, read_write_scope: :read)
+      assert {:ok, cast} = Cast.cast(schema, body, schemas)
 
       assert %NotificationResponseSchema{
                id: notification_id,
@@ -356,7 +355,7 @@ defmodule PhoenixEctoOpenApiDemoWeb.NotificationControllerTest do
 
       schemas = @api_spec.components.schemas
       schema = Map.fetch!(schemas, "NotificationResponse")
-      assert {:ok, cast} = Cast.cast(schema, body, schemas, read_write_scope: :read)
+      assert {:ok, cast} = Cast.cast(schema, body, schemas)
 
       assert %NotificationResponseSchema{
                id: notification_id,
@@ -380,7 +379,7 @@ defmodule PhoenixEctoOpenApiDemoWeb.NotificationControllerTest do
 
       schemas = @api_spec.components.schemas
       schema = Map.fetch!(schemas, "NotificationResponse")
-      assert {:ok, cast} = Cast.cast(schema, body, schemas, read_write_scope: :read)
+      assert {:ok, cast} = Cast.cast(schema, body, schemas)
 
       assert %NotificationResponseSchema{
                id: notification_id,
@@ -422,7 +421,7 @@ defmodule PhoenixEctoOpenApiDemoWeb.NotificationControllerTest do
 
       schemas = @api_spec.components.schemas
       schema = Map.fetch!(schemas, "NotificationResponse")
-      assert {:ok, cast} = Cast.cast(schema, body, schemas, read_write_scope: :read)
+      assert {:ok, cast} = Cast.cast(schema, body, schemas)
 
       assert %NotificationResponseSchema{
                id: id,
@@ -454,7 +453,7 @@ defmodule PhoenixEctoOpenApiDemoWeb.NotificationControllerTest do
 
       schemas = @api_spec.components.schemas
       schema = Map.fetch!(schemas, "NotificationResponse")
-      assert {:ok, cast} = Cast.cast(schema, body, schemas, read_write_scope: :read)
+      assert {:ok, cast} = Cast.cast(schema, body, schemas)
 
       # The channel must have cast into the new variant, not the original.
       assert %NotificationResponseSchema{
@@ -494,7 +493,7 @@ defmodule PhoenixEctoOpenApiDemoWeb.NotificationControllerTest do
 
       schemas = @api_spec.components.schemas
       schema = Map.fetch!(schemas, "NotificationResponse")
-      assert {:ok, cast} = Cast.cast(schema, body, schemas, read_write_scope: :read)
+      assert {:ok, cast} = Cast.cast(schema, body, schemas)
 
       assert %NotificationResponseSchema{
                id: id,

--- a/test/ex_open_api_utils/polymorphic_cast_round_trip_test.exs
+++ b/test/ex_open_api_utils/polymorphic_cast_round_trip_test.exs
@@ -65,7 +65,7 @@ defmodule ExOpenApiUtils.PolymorphicCastRoundTripTest do
   defp cast_response(wire_map, schema_title) do
     schemas = resolved_schemas()
     schema = Map.fetch!(schemas, schema_title)
-    Cast.cast(schema, wire_map, schemas, read_write_scope: :read)
+    Cast.cast(schema, wire_map, schemas)
   end
 
   describe "GH-30 round-trip — Notification.channel preserves the discriminator on the variant struct" do


### PR DESCRIPTION
## Summary

All nine `Cast.cast/4` call sites in [notification_controller_test.exs](examples/phoenix_ecto_open_api_demo/test/phoenix_ecto_open_api_demo_web/controllers/notification_controller_test.exs) and the one in [polymorphic_cast_round_trip_test.exs](test/ex_open_api_utils/polymorphic_cast_round_trip_test.exs) were passing `read_write_scope: :read`. That opt is cosmetic for this library.

## Why it's a no-op

`read_write_scope` in `OpenApiSpex.Cast.cast/4` filters the `required` list at [cast/utils.ex:19-46](deps/open_api_spex/lib/open_api_spex/cast/utils.ex#L19-L46):

```elixir
case {ctx.read_write_scope, ctx.schema.properties[key]} do
  {:read, %{writeOnly: true}} -> false
  {:write, %{readOnly: true}} -> false
  _ -> true
end
```

It exists so consumers who keep one schema per resource and model direction purely via `readOnly` / `writeOnly` annotations can still cast cleanly.

This library takes the *two-schema* path instead: `__submodule_spec__/4` in [lib/ex_open_api_utils.ex:510](lib/ex_open_api_utils.ex#L510) emits `NotificationRequest` and `NotificationResponse` as physically separate schemas, each containing only the properties relevant to its direction. `NotificationResponse.required` therefore contains zero `writeOnly: true` entries — the scope filter runs against an empty set.

## Empirical verification

Stripped every `read_write_scope: :read` argument, ran both full suites:

- **library** — `mix test` — 95 tests, 0 failures
- **phoenix_ecto_open_api_demo** — `MIX_ENV=test mix test` — 90 tests, 0 failures

The GH-30 regression lock is intact. The response-side round-trip still routes through the discriminator, still builds `%NotificationEmailResponse{}` / `%NotificationSmsResponse{}` / `%NotificationWebhookResponse{}`, still sees `channel_type` on the defstruct.

## Test plan

- [x] `mix test` (library) green
- [x] `MIX_ENV=test mix test` (phoenix_ecto_open_api_demo) green
- [x] Manual diff review — only `, read_write_scope: :read` removed from `Cast.cast/4` call sites plus one moduledoc paragraph trim