### PR TITLE
GH-34 feat(polymorphic): support arbitrary-depth nesting via self-stamping parent-contextual siblings 

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -42,7 +42,14 @@
           {Credo.Check.Refactor.CondStatements, []},
           {Credo.Check.Refactor.CyclomaticComplexity, []},
           {Credo.Check.Refactor.FunctionArity, []},
-          {Credo.Check.Refactor.LongQuoteBlocks, []},
+          # `__before_compile__` macros in this library orchestrate multiple
+          # codegen steps (build polymorphic_variants, generate parent-
+          # contextual siblings, derive Mapper impls, create Request/Response
+          # submodules) inside a single quote block. Extracting sections purely
+          # to hit the default 150-line ceiling fragments locally-cohesive
+          # logic across helpers. 200 accommodates legitimate codegen length
+          # without inviting actually sprawling quote blocks.
+          {Credo.Check.Refactor.LongQuoteBlocks, [max_line_count: 200]},
           {Credo.Check.Refactor.MapInto, []},
           {Credo.Check.Refactor.MatchInCondition, []},
           {Credo.Check.Refactor.NegatedConditionsInUnless, []},

--- a/examples/phoenix_ecto_open_api_demo/integration-tests/tests/subscriptions.test.ts
+++ b/examples/phoenix_ecto_open_api_demo/integration-tests/tests/subscriptions.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  subscriptionCreate,
+  subscriptionShow,
+} from "../generated/sdk.gen";
+import * as zSchemas from "../generated/zod.gen";
+
+/**
+ * GH-34 HTTP regression lock against a live Phoenix surface.
+ *
+ * Exercises the nested polymorphic shape end-to-end through the same
+ * production-style stack as notifications.test.ts: ky HTTP client from
+ * @hey-api/client-ky, typed SDK functions from @hey-api/sdk, zod schemas
+ * from the zod plugin for runtime response validation. The tests match
+ * the example app's 3-level subscription tree:
+ *
+ *   Subscription (level 0)
+ *   ├── :destination — polymorphic [webhook, email]
+ *   │
+ *   ├── WebhookDestination (level 1)
+ *   │   └── :auth — polymorphic [oauth, basic]
+ *   │       │
+ *   │       ├── OAuthAuth (level 2)
+ *   │       │   └── :grant — polymorphic [client_credentials, authorization_code]
+ *   │       │       │
+ *   │       │       ├── ClientCredentialsGrant (level 3 leaf)
+ *   │       │       └── AuthorizationCodeGrant (level 3 leaf)
+ *   │       │
+ *   │       └── BasicAuth (level 2 leaf)
+ *   │
+ *   └── EmailDestination (level 1 leaf)
+ *
+ * Before 0.15.0, any request with nesting depth >= 2 raised
+ * `PolymorphicEmbed.raise_cannot_infer_type_from_data/1` on the Phoenix
+ * side, surfacing to the client as a 500 (or 422, depending on the
+ * FallbackController). After the self-stamping parent-contextual sibling
+ * Mapper impls land, every depth routes cleanly through the changeset.
+ */
+
+// The zod plugin emits schemas under names keyed off the OpenAPI type
+// title. Grab loosely because the exact symbol layout can shift between
+// hey-api versions — fall back to dynamic access so a version bump
+// doesn't silently skip validation.
+const subscriptionResponseSchema =
+  (zSchemas as Record<string, unknown>)["zSubscriptionResponse"] ??
+  (zSchemas as Record<string, unknown>)["SubscriptionResponse"] ??
+  (zSchemas as Record<string, unknown>)["subscriptionResponseSchema"];
+
+function validate<T>(data: T): T {
+  if (
+    subscriptionResponseSchema &&
+    typeof (subscriptionResponseSchema as { parse?: unknown }).parse ===
+      "function"
+  ) {
+    return (
+      subscriptionResponseSchema as { parse: (v: unknown) => T }
+    ).parse(data);
+  }
+  return data;
+}
+
+describe("POST /api/subscriptions — nesting depth 3 (webhook → oauth → client_credentials)", () => {
+  test("three stacked discriminators survive the full HTTP round-trip", async () => {
+    const { data, error, response } = await subscriptionCreate({
+      body: {
+        name: "Order events subscription",
+        destination: {
+          destination_type: "webhook",
+          url: "https://hooks.example.com/orders",
+          method: "POST",
+          auth: {
+            auth_type: "oauth",
+            token_url: "https://auth.example.com/oauth/token",
+            client_id: "client-abc-123",
+            grant: {
+              grant_type: "client_credentials",
+              client_secret: "sk-example-secret",
+              scope: "read:events write:webhooks",
+            },
+          },
+        },
+      },
+    });
+
+    expect(error).toBeUndefined();
+    expect(response.status).toBe(201);
+    expect(data).toBeDefined();
+
+    const validated = validate(data!) as typeof data;
+
+    // Level 1 discriminator
+    expect(validated!.destination.destination_type).toBe("webhook");
+
+    // Level 2 discriminator — this is the GH-34 gap
+    if (validated!.destination.destination_type === "webhook") {
+      expect(validated!.destination.url).toBe(
+        "https://hooks.example.com/orders",
+      );
+      expect(validated!.destination.method).toBe("POST");
+      expect(validated!.destination.auth.auth_type).toBe("oauth");
+
+      // Level 3 discriminator — depth-unbounded after the fix
+      if (validated!.destination.auth.auth_type === "oauth") {
+        expect(validated!.destination.auth.token_url).toBe(
+          "https://auth.example.com/oauth/token",
+        );
+        expect(validated!.destination.auth.client_id).toBe("client-abc-123");
+        expect(validated!.destination.auth.grant.grant_type).toBe(
+          "client_credentials",
+        );
+
+        if (
+          validated!.destination.auth.grant.grant_type ===
+          "client_credentials"
+        ) {
+          expect(validated!.destination.auth.grant.scope).toBe(
+            "read:events write:webhooks",
+          );
+        }
+      }
+    }
+  });
+});
+
+describe("POST /api/subscriptions — nesting depth 3 (webhook → oauth → authorization_code)", () => {
+  test("alternate level-3 grant variant routes through the same chain", async () => {
+    const { data, error, response } = await subscriptionCreate({
+      body: {
+        name: "Authz-code subscription",
+        destination: {
+          destination_type: "webhook",
+          url: "https://hooks.example.com/authz",
+          method: "POST",
+          auth: {
+            auth_type: "oauth",
+            token_url: "https://auth.example.com/oauth/token",
+            client_id: "client-zzz-789",
+            grant: {
+              grant_type: "authorization_code",
+              authorization_code: "ac_example_code",
+              redirect_uri: "https://app.example.com/oauth/callback",
+            },
+          },
+        },
+      },
+    });
+
+    expect(error).toBeUndefined();
+    expect(response.status).toBe(201);
+
+    const validated = validate(data!) as typeof data;
+
+    expect(validated!.destination.destination_type).toBe("webhook");
+    if (validated!.destination.destination_type === "webhook") {
+      expect(validated!.destination.auth.auth_type).toBe("oauth");
+
+      if (validated!.destination.auth.auth_type === "oauth") {
+        expect(validated!.destination.auth.grant.grant_type).toBe(
+          "authorization_code",
+        );
+
+        if (
+          validated!.destination.auth.grant.grant_type ===
+          "authorization_code"
+        ) {
+          expect(validated!.destination.auth.grant.redirect_uri).toBe(
+            "https://app.example.com/oauth/callback",
+          );
+        }
+      }
+    }
+  });
+});
+
+describe("POST /api/subscriptions — nesting depth 2 (webhook → basic)", () => {
+  test("two stacked discriminators route correctly, terminates at BasicAuth leaf", async () => {
+    const { data, error, response } = await subscriptionCreate({
+      body: {
+        name: "Infra alerts",
+        destination: {
+          destination_type: "webhook",
+          url: "https://hooks.example.com/infra",
+          method: "POST",
+          auth: {
+            auth_type: "basic",
+            username: "alice",
+            password: "s3cret",
+          },
+        },
+      },
+    });
+
+    expect(error).toBeUndefined();
+    expect(response.status).toBe(201);
+
+    const validated = validate(data!) as typeof data;
+
+    expect(validated!.destination.destination_type).toBe("webhook");
+    if (validated!.destination.destination_type === "webhook") {
+      expect(validated!.destination.auth.auth_type).toBe("basic");
+
+      if (validated!.destination.auth.auth_type === "basic") {
+        expect(validated!.destination.auth.username).toBe("alice");
+      }
+    }
+  });
+});
+
+describe("POST /api/subscriptions — nesting depth 1 (flat email)", () => {
+  test("0.14.0 single-level parity regression lock", async () => {
+    const { data, error, response } = await subscriptionCreate({
+      body: {
+        name: "Ops digest",
+        destination: {
+          destination_type: "email",
+          recipient: "ops@example.com",
+        },
+      },
+    });
+
+    expect(error).toBeUndefined();
+    expect(response.status).toBe(201);
+
+    const validated = validate(data!) as typeof data;
+
+    expect(validated!.destination.destination_type).toBe("email");
+    if (validated!.destination.destination_type === "email") {
+      expect(validated!.destination.recipient).toBe("ops@example.com");
+    }
+  });
+});
+
+describe("GET /api/subscriptions/:id — 3-level nested round-trip preserves all discriminators", () => {
+  test("show returns the same discriminators the create body sent at every nesting level", async () => {
+    const { data: created } = await subscriptionCreate({
+      body: {
+        name: "Round-trip nested test",
+        destination: {
+          destination_type: "webhook",
+          url: "https://hooks.example.com/roundtrip",
+          method: "POST",
+          auth: {
+            auth_type: "oauth",
+            token_url: "https://auth.example.com/oauth/token",
+            client_id: "client-roundtrip",
+            grant: {
+              grant_type: "client_credentials",
+              client_secret: "sk-roundtrip-secret",
+              scope: "read:events",
+            },
+          },
+        },
+      },
+    });
+
+    expect(created).toBeDefined();
+    const id = created!.id!;
+
+    const {
+      data: fetched,
+      error,
+      response,
+    } = await subscriptionShow({ path: { id } });
+
+    expect(error).toBeUndefined();
+    expect(response.status).toBe(200);
+
+    const validated = validate(fetched!) as typeof fetched;
+
+    expect(validated!.id).toBe(id);
+    expect(validated!.destination.destination_type).toBe("webhook");
+
+    if (validated!.destination.destination_type === "webhook") {
+      expect(validated!.destination.auth.auth_type).toBe("oauth");
+
+      if (validated!.destination.auth.auth_type === "oauth") {
+        expect(validated!.destination.auth.grant.grant_type).toBe(
+          "client_credentials",
+        );
+      }
+    }
+  });
+});

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/subscription_context.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/subscription_context.ex
@@ -1,0 +1,38 @@
+defmodule PhoenixEctoOpenApiDemo.SubscriptionContext do
+  @moduledoc """
+  Context module for event subscriptions with a nested polymorphic
+  delivery destination.
+
+  Demonstrates the GH-34 nested polymorphic pattern end-to-end:
+  `Subscription.destination` → (`WebhookDestination` → `:auth` → `OAuthAuth`
+  → `:grant` → leaf grants) or `EmailDestination` (flat). Three
+  `open_api_polymorphic_property` macros stacked, handled transparently
+  by the library's self-stamping parent-contextual sibling Mapper impls.
+  """
+  import Ecto.Query, warn: false
+
+  alias PhoenixEctoOpenApiDemo.Repo
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext.Subscription
+
+  def list_subscriptions do
+    Repo.all(Subscription)
+  end
+
+  def get_subscription!(id), do: Repo.get!(Subscription, id)
+
+  def create_subscription(attrs) do
+    %Subscription{}
+    |> Subscription.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_subscription(%Subscription{} = subscription, attrs) do
+    subscription
+    |> Subscription.changeset(attrs)
+    |> Repo.update()
+  end
+
+  def delete_subscription(%Subscription{} = subscription) do
+    Repo.delete(subscription)
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/subscription_context/authorization_code_grant.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/subscription_context/authorization_code_grant.ex
@@ -1,0 +1,43 @@
+defmodule PhoenixEctoOpenApiDemo.SubscriptionContext.AuthorizationCodeGrant do
+  @moduledoc """
+  OAuth 2.0 authorization-code grant leaf (level 3) in the nested polymorphic
+  subscription tree. Flat — no further polymorphic children.
+  """
+  use ExOpenApiUtils
+
+  open_api_property(
+    key: :authorization_code,
+    schema: %Schema{
+      type: :string,
+      writeOnly: true,
+      example: "ac_example_code"
+    }
+  )
+
+  open_api_property(
+    key: :redirect_uri,
+    schema: %Schema{
+      type: :string,
+      format: :uri,
+      example: "https://app.example.com/oauth/callback"
+    }
+  )
+
+  embedded_schema do
+    field :authorization_code, :string
+    field :redirect_uri, :string
+  end
+
+  open_api_schema(
+    title: "AuthorizationCodeGrant",
+    description: "OAuth 2.0 authorization-code grant",
+    required: [:authorization_code, :redirect_uri],
+    properties: [:authorization_code, :redirect_uri]
+  )
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:authorization_code, :redirect_uri])
+    |> validate_required([:authorization_code, :redirect_uri])
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/subscription_context/basic_auth.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/subscription_context/basic_auth.ex
@@ -1,0 +1,36 @@
+defmodule PhoenixEctoOpenApiDemo.SubscriptionContext.BasicAuth do
+  @moduledoc """
+  HTTP Basic authentication leaf (level 2) in the nested polymorphic
+  subscription tree. Flat — terminates at level 2, alongside `OAuthAuth`
+  which has its own level-3 polymorphic children.
+  """
+  use ExOpenApiUtils
+
+  open_api_property(
+    key: :username,
+    schema: %Schema{type: :string, example: "alice"}
+  )
+
+  open_api_property(
+    key: :password,
+    schema: %Schema{type: :string, writeOnly: true, example: "s3cret"}
+  )
+
+  embedded_schema do
+    field :username, :string
+    field :password, :string
+  end
+
+  open_api_schema(
+    title: "BasicAuth",
+    description: "HTTP Basic authentication",
+    required: [:username, :password],
+    properties: [:username, :password]
+  )
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:username, :password])
+    |> validate_required([:username, :password])
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/subscription_context/client_credentials_grant.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/subscription_context/client_credentials_grant.ex
@@ -1,0 +1,39 @@
+defmodule PhoenixEctoOpenApiDemo.SubscriptionContext.ClientCredentialsGrant do
+  @moduledoc """
+  OAuth 2.0 client-credentials grant leaf (level 3) in the nested polymorphic
+  subscription tree. Flat — no further polymorphic children.
+  """
+  use ExOpenApiUtils
+
+  open_api_property(
+    key: :client_secret,
+    schema: %Schema{
+      type: :string,
+      writeOnly: true,
+      example: "sk-example-client-secret"
+    }
+  )
+
+  open_api_property(
+    key: :scope,
+    schema: %Schema{type: :string, example: "read:events write:webhooks"}
+  )
+
+  embedded_schema do
+    field :client_secret, :string
+    field :scope, :string
+  end
+
+  open_api_schema(
+    title: "ClientCredentialsGrant",
+    description: "OAuth 2.0 client-credentials grant",
+    required: [:client_secret],
+    properties: [:client_secret, :scope]
+  )
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:client_secret, :scope])
+    |> validate_required([:client_secret])
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/subscription_context/email_destination.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/subscription_context/email_destination.ex
@@ -1,0 +1,30 @@
+defmodule PhoenixEctoOpenApiDemo.SubscriptionContext.EmailDestination do
+  @moduledoc """
+  Email delivery destination leaf (level 1) in the nested polymorphic
+  subscription tree. Flat — provides contrast against `WebhookDestination`
+  which has its own nested polymorphic children.
+  """
+  use ExOpenApiUtils
+
+  open_api_property(
+    key: :recipient,
+    schema: %Schema{type: :string, format: :email, example: "ops@example.com"}
+  )
+
+  embedded_schema do
+    field :recipient, :string
+  end
+
+  open_api_schema(
+    title: "EmailDestination",
+    description: "Email delivery destination",
+    required: [:recipient],
+    properties: [:recipient]
+  )
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:recipient])
+    |> validate_required([:recipient])
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/subscription_context/oauth_auth.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/subscription_context/oauth_auth.ex
@@ -1,0 +1,68 @@
+defmodule PhoenixEctoOpenApiDemo.SubscriptionContext.OAuthAuth do
+  @moduledoc """
+  OAuth 2.0 authentication (level 2) with a polymorphic `:grant` field
+  in the nested subscription tree. This is the intermediate level-2
+  polymorphic parent — the thing that failed before GH-34 because its
+  nested `:grant` discriminator was dropped during `Mapper.to_map` on
+  the `:from_open_api` direction.
+  """
+  use ExOpenApiUtils
+
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext.AuthorizationCodeGrant
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext.ClientCredentialsGrant
+
+  import PolymorphicEmbed
+
+  open_api_property(
+    key: :token_url,
+    schema: %Schema{
+      type: :string,
+      format: :uri,
+      example: "https://auth.example.com/oauth/token"
+    }
+  )
+
+  open_api_property(
+    key: :client_id,
+    schema: %Schema{type: :string, example: "client-abc-123"}
+  )
+
+  open_api_polymorphic_property(
+    key: :grant,
+    type_field_name: :__type__,
+    open_api_discriminator_property: "grant_type",
+    variants: [
+      client_credentials: ClientCredentialsGrant,
+      authorization_code: AuthorizationCodeGrant
+    ]
+  )
+
+  embedded_schema do
+    field :token_url, :string
+    field :client_id, :string
+
+    polymorphic_embeds_one(:grant,
+      types: [
+        client_credentials: ClientCredentialsGrant,
+        authorization_code: AuthorizationCodeGrant
+      ],
+      type_field_name: :__type__,
+      on_type_not_found: :raise,
+      on_replace: :update
+    )
+  end
+
+  open_api_schema(
+    title: "OAuth",
+    description: "OAuth 2.0 authentication with a polymorphic grant type",
+    required: [:token_url, :client_id, :grant],
+    properties: [:token_url, :client_id, :grant]
+  )
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:token_url, :client_id])
+    |> validate_required([:token_url, :client_id])
+    |> cast_polymorphic_embed(:grant, required: true)
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/subscription_context/subscription.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/subscription_context/subscription.ex
@@ -1,0 +1,83 @@
+defmodule PhoenixEctoOpenApiDemo.SubscriptionContext.Subscription do
+  @moduledoc """
+  Top-level parent schema (level 0) for event subscriptions with a
+  polymorphic `:destination`. Demonstrates the GH-34 nested polymorphic
+  support — one of the destination variants (`WebhookDestination`) is
+  itself a polymorphic parent with a nested `:auth` field, which in turn
+  has a variant (`OAuthAuth`) that's itself a polymorphic parent with a
+  `:grant` field. Three stacked `open_api_polymorphic_property` macros.
+
+  Before 0.15.0 this shape failed during `Mapper.to_map` on the
+  `:from_open_api` direction: `:__type__` was stamped on the outer
+  destination submap but not on the nested auth / grant submaps, so
+  `cast_polymorphic_embed/3` at the nested levels raised
+  `PolymorphicEmbed.raise_cannot_infer_type_from_data/1`. The fix (Option 3
+  self-stamping parent-contextual siblings) makes each parent-contextual
+  sibling's Mapper impl stamp its own discriminator atom on its own result
+  map from compile-time constants, so nested chains work at arbitrary depth.
+  """
+  use ExOpenApiUtils
+
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext.EmailDestination
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext.WebhookDestination
+
+  import PolymorphicEmbed
+
+  open_api_property(
+    key: :id,
+    schema: %Schema{
+      type: :string,
+      format: :uuid,
+      example: "b7f4c2a0-1e3d-4a7e-9c6b-8f2d1e5c3a9b",
+      readOnly: true
+    }
+  )
+
+  open_api_property(
+    key: :name,
+    schema: %Schema{type: :string, example: "Order events subscription"}
+  )
+
+  open_api_polymorphic_property(
+    key: :destination,
+    type_field_name: :__type__,
+    open_api_discriminator_property: "destination_type",
+    variants: [
+      webhook: WebhookDestination,
+      email: EmailDestination
+    ]
+  )
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "subscriptions" do
+    field :name, :string
+
+    polymorphic_embeds_one(:destination,
+      types: [
+        webhook: WebhookDestination,
+        email: EmailDestination
+      ],
+      type_field_name: :__type__,
+      on_type_not_found: :raise,
+      on_replace: :update
+    )
+
+    timestamps()
+  end
+
+  open_api_schema(
+    title: "Subscription",
+    description: "Event subscription with a polymorphic delivery destination",
+    required: [:name, :destination],
+    properties: [:id, :name, :destination],
+    tags: ["Subscription"]
+  )
+
+  def changeset(subscription, attrs) do
+    subscription
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+    |> cast_polymorphic_embed(:destination, required: true)
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/subscription_context/webhook_destination.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/subscription_context/webhook_destination.ex
@@ -1,0 +1,72 @@
+defmodule PhoenixEctoOpenApiDemo.SubscriptionContext.WebhookDestination do
+  @moduledoc """
+  HTTP webhook delivery destination (level 1) with a polymorphic `:auth`
+  field in the nested subscription tree. Intermediate polymorphic parent —
+  its `:auth` field holds the inner polymorphic child that failed before
+  GH-34 because its nested `:__type__` atom was dropped during
+  `Mapper.to_map` on the `:from_open_api` direction.
+  """
+  use ExOpenApiUtils
+
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext.BasicAuth
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext.OAuthAuth
+
+  import PolymorphicEmbed
+
+  open_api_property(
+    key: :url,
+    schema: %Schema{
+      type: :string,
+      format: :uri,
+      example: "https://hooks.example.com/deliveries"
+    }
+  )
+
+  open_api_property(
+    key: :method,
+    schema: %Schema{
+      type: :string,
+      enum: ["POST", "PUT", "PATCH"],
+      example: "POST"
+    }
+  )
+
+  open_api_polymorphic_property(
+    key: :auth,
+    type_field_name: :__type__,
+    open_api_discriminator_property: "auth_type",
+    variants: [
+      oauth: OAuthAuth,
+      basic: BasicAuth
+    ]
+  )
+
+  embedded_schema do
+    field :url, :string
+    field :method, :string
+
+    polymorphic_embeds_one(:auth,
+      types: [
+        oauth: OAuthAuth,
+        basic: BasicAuth
+      ],
+      type_field_name: :__type__,
+      on_type_not_found: :raise,
+      on_replace: :update
+    )
+  end
+
+  open_api_schema(
+    title: "WebhookDestination",
+    description: "HTTP webhook delivery destination with a polymorphic auth mechanism",
+    required: [:url, :method, :auth],
+    properties: [:url, :method, :auth]
+  )
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:url, :method])
+    |> validate_required([:url, :method])
+    |> cast_polymorphic_embed(:auth, required: true)
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo_web/controllers/subscription_controller.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo_web/controllers/subscription_controller.ex
@@ -1,0 +1,141 @@
+defmodule PhoenixEctoOpenApiDemoWeb.SubscriptionController do
+  @moduledoc """
+  Controller for the nested-polymorphic-backed `Subscription` resource.
+
+  This is the GH-34 end-to-end lock. The `:destination` property is a
+  polymorphic oneOf over `[webhook, email]`, and the `webhook` variant
+  (`WebhookDestination`) has a further polymorphic `:auth` over
+  `[oauth, basic]`, and the `oauth` variant (`OAuthAuth`) has a further
+  polymorphic `:grant` over `[client_credentials, authorization_code]`.
+  Three stacked `open_api_polymorphic_property` macros.
+
+  Before 0.15.0, posting a subscription with `destination_type=webhook`,
+  `auth_type=oauth`, `grant_type=client_credentials` raised
+  `PolymorphicEmbed.raise_cannot_infer_type_from_data/1` at the nested
+  `cast_polymorphic_embed(:auth)` or `cast_polymorphic_embed(:grant)`
+  call because `Mapper.to_map` dropped `:__type__` at the nested levels.
+  The self-stamping parent-contextual sibling Mapper impls close that gap.
+  """
+  use PhoenixEctoOpenApiDemoWeb, :controller
+
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext.Subscription
+
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.SubscriptionRequest
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.SubscriptionResponse
+
+  plug OpenApiSpex.Plug.CastAndValidate, json_render_error_v2: true
+
+  action_fallback PhoenixEctoOpenApiDemoWeb.FallbackController
+
+  tags(["Subscription"])
+
+  operation(:index,
+    summary: "Lists subscriptions (with nested polymorphic destinations)",
+    operation_id: "Subscription.list",
+    responses: [
+      ok:
+        {"Subscription list response", "application/json",
+         %Schema{
+           type: :array,
+           description: "list of subscriptions — each destination is a nested polymorphic tree",
+           items: SubscriptionResponse
+         }}
+    ]
+  )
+
+  def index(conn, _params) do
+    subscriptions = SubscriptionContext.list_subscriptions()
+    render(conn, :index, subscriptions: subscriptions)
+  end
+
+  operation(:create,
+    summary: "Creates a subscription with a nested polymorphic destination",
+    operation_id: "Subscription.create",
+    request_body: {"Subscription creation body", "application/json", SubscriptionRequest},
+    responses: [
+      created: {"Subscription response", "application/json", SubscriptionResponse}
+    ]
+  )
+
+  def create(%{body_params: %SubscriptionRequest{} = request} = conn, _params) do
+    with {:ok, %Subscription{} = subscription} <-
+           SubscriptionContext.create_subscription(request) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", ~p"/api/subscriptions/#{subscription}")
+      |> render(:show, subscription: subscription)
+    end
+  end
+
+  operation(:show,
+    summary: "Fetches a subscription",
+    operation_id: "Subscription.show",
+    parameters: [
+      id: [
+        in: :path,
+        description: "Subscription ID",
+        type: :string,
+        example: "b7f4c2a0-1e3d-4a7e-9c6b-8f2d1e5c3a9b"
+      ]
+    ],
+    responses: [
+      ok: {"Subscription response", "application/json", SubscriptionResponse}
+    ]
+  )
+
+  def show(conn, %{id: id}) do
+    subscription = SubscriptionContext.get_subscription!(id)
+    render(conn, :show, subscription: subscription)
+  end
+
+  operation(:update,
+    summary: "Updates a subscription",
+    operation_id: "Subscription.update",
+    parameters: [
+      id: [
+        in: :path,
+        description: "Subscription ID",
+        type: :string,
+        example: "b7f4c2a0-1e3d-4a7e-9c6b-8f2d1e5c3a9b"
+      ]
+    ],
+    request_body: {"Subscription update body", "application/json", SubscriptionRequest},
+    responses: [
+      ok: {"Subscription response", "application/json", SubscriptionResponse}
+    ]
+  )
+
+  def update(%{body_params: %SubscriptionRequest{} = request} = conn, %{id: id}) do
+    subscription = SubscriptionContext.get_subscription!(id)
+
+    with {:ok, %Subscription{} = subscription} <-
+           SubscriptionContext.update_subscription(subscription, request) do
+      render(conn, :show, subscription: subscription)
+    end
+  end
+
+  operation(:delete,
+    summary: "Deletes an existing subscription",
+    operation_id: "Subscription.delete",
+    parameters: [
+      id: [
+        in: :path,
+        description: "Subscription ID",
+        type: :string,
+        example: "b7f4c2a0-1e3d-4a7e-9c6b-8f2d1e5c3a9b"
+      ]
+    ],
+    responses: [
+      no_content: "Empty Response"
+    ]
+  )
+
+  def delete(conn, %{id: id}) do
+    subscription = SubscriptionContext.get_subscription!(id)
+
+    with {:ok, %Subscription{}} <- SubscriptionContext.delete_subscription(subscription) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo_web/controllers/subscription_json.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo_web/controllers/subscription_json.ex
@@ -1,0 +1,17 @@
+defmodule PhoenixEctoOpenApiDemoWeb.SubscriptionJSON do
+  @moduledoc """
+  JSON renderer for subscriptions. `ExOpenApiUtils.Mapper.to_map/1` handles
+  everything — including stamping the wire discriminators
+  (`"destination_type" => "webhook"`, `"auth_type" => "oauth"`,
+  `"grant_type" => "client_credentials"`) at every nesting level of the
+  polymorphic tree.
+  """
+
+  def index(%{subscriptions: subscriptions}) do
+    Enum.map(subscriptions, &ExOpenApiUtils.Mapper.to_map/1)
+  end
+
+  def show(%{subscription: subscription}) do
+    ExOpenApiUtils.Mapper.to_map(subscription)
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo_web/router.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo_web/router.ex
@@ -24,6 +24,7 @@ defmodule PhoenixEctoOpenApiDemoWeb.Router do
     resources "/users", UserController, except: [:new, :edit]
     resources "/businesses", BusinessController, except: [:new, :edit]
     resources "/notifications", NotificationController, except: [:new, :edit]
+    resources "/subscriptions", SubscriptionController, except: [:new, :edit]
   end
 
   # Enable Swoosh mailbox preview in development

--- a/examples/phoenix_ecto_open_api_demo/priv/repo/migrations/20260411120000_create_subscriptions.exs
+++ b/examples/phoenix_ecto_open_api_demo/priv/repo/migrations/20260411120000_create_subscriptions.exs
@@ -1,0 +1,13 @@
+defmodule PhoenixEctoOpenApiDemo.Repo.Migrations.CreateSubscriptions do
+  use Ecto.Migration
+
+  def change do
+    create table(:subscriptions, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :name, :string, null: false
+      add :destination, :map, null: false
+
+      timestamps()
+    end
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/test/phoenix_ecto_open_api_demo_web/controllers/subscription_controller_test.exs
+++ b/examples/phoenix_ecto_open_api_demo/test/phoenix_ecto_open_api_demo_web/controllers/subscription_controller_test.exs
@@ -1,0 +1,374 @@
+defmodule PhoenixEctoOpenApiDemoWeb.SubscriptionControllerTest do
+  @moduledoc """
+  End-to-end lock for GH-34 nested polymorphic `open_api_polymorphic_property`
+  support. Each test goes through the full Phoenix pipeline — `CastAndValidate`
+  on the request, changeset via `ExOpenApiUtils.Changeset.cast`, Repo insert,
+  render via `ExOpenApiUtils.Mapper.to_map`, and finally re-casts the wire
+  JSON response via `OpenApiSpex.Cast.cast/4` against the resolved
+  `SubscriptionResponse` schema to produce a typed struct tree for
+  deep-pattern matching.
+
+  Before 0.15.0, any test with nesting depth >= 2 would fail because
+  `Mapper.to_map` didn't stamp `:__type__` on the nested destination submaps
+  during the outbound serialization path. `cast_polymorphic_embed/3` at the
+  nested level then raised `PolymorphicEmbed.raise_cannot_infer_type_from_data/1`.
+  The self-stamping parent-contextual sibling Mapper impls (Option 3) close
+  that gap — each sibling's `defimpl` stamps its own Ecto type-field atom on
+  its own result map from compile-time constants.
+  """
+  use PhoenixEctoOpenApiDemoWeb.ConnCase
+
+  import PhoenixEctoOpenApiDemo.SubscriptionContextFixtures
+
+  alias OpenApiSpex.Cast
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext.AuthorizationCodeGrant
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext.BasicAuth
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext.ClientCredentialsGrant
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext.EmailDestination
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext.OAuthAuth
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext.Subscription
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext.WebhookDestination
+
+  # Auto-generated OpenApiSpex Response submodules. Flat names per the
+  # library's naming: `<parent_title><variant_title><direction_suffix>`.
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.OAuthAuthorizationCodeGrantResponse
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.OAuthClientCredentialsGrantResponse
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.SubscriptionEmailDestinationResponse
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.SubscriptionResponse, as: SubscriptionResponseSchema
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.SubscriptionWebhookDestinationResponse
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.WebhookDestinationBasicAuthResponse
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.WebhookDestinationOAuthResponse
+
+  @api_spec PhoenixEctoOpenApiDemoWeb.ApiSpec.spec()
+
+  @email_attrs %{
+    name: "Ops digest",
+    destination: %{
+      destination_type: "email",
+      recipient: "ops@example.com"
+    }
+  }
+
+  @basic_auth_attrs %{
+    name: "Infra alerts",
+    destination: %{
+      destination_type: "webhook",
+      url: "https://hooks.example.com/infra",
+      method: "POST",
+      auth: %{
+        auth_type: "basic",
+        username: "alice",
+        password: "s3cret"
+      }
+    }
+  }
+
+  @client_credentials_attrs %{
+    name: "Order events subscription",
+    destination: %{
+      destination_type: "webhook",
+      url: "https://hooks.example.com/orders",
+      method: "POST",
+      auth: %{
+        auth_type: "oauth",
+        token_url: "https://auth.example.com/oauth/token",
+        client_id: "client-abc-123",
+        grant: %{
+          grant_type: "client_credentials",
+          client_secret: "sk-example-secret",
+          scope: "read:events write:webhooks"
+        }
+      }
+    }
+  }
+
+  @authorization_code_attrs %{
+    name: "Authz-code subscription",
+    destination: %{
+      destination_type: "webhook",
+      url: "https://hooks.example.com/authz",
+      method: "POST",
+      auth: %{
+        auth_type: "oauth",
+        token_url: "https://auth.example.com/oauth/token",
+        client_id: "client-zzz-789",
+        grant: %{
+          grant_type: "authorization_code",
+          authorization_code: "ac_example_code",
+          redirect_uri: "https://app.example.com/oauth/callback"
+        }
+      }
+    }
+  }
+
+  setup %{conn: conn} do
+    {:ok,
+     conn:
+       conn
+       |> put_req_header("accept", "application/json")
+       |> put_req_header("content-type", "application/json")}
+  end
+
+  defp cast_response(body) do
+    schemas = @api_spec.components.schemas
+    schema = Map.fetch!(schemas, "SubscriptionResponse")
+    Cast.cast(schema, body, schemas)
+  end
+
+  describe "create — nesting depth 3 (webhook → oauth → client_credentials)" do
+    test "returns 201 with all three discriminators on the wire, cast tree has correct leaf type, Ecto tree persisted",
+         %{conn: conn} do
+      conn = post(conn, ~p"/api/subscriptions", @client_credentials_attrs)
+      body = json_response(conn, 201)
+
+      # Wire shape — the three wire discriminators at three nesting levels
+      assert body["destination"]["destination_type"] == "webhook"
+      assert body["destination"]["auth"]["auth_type"] == "oauth"
+      assert body["destination"]["auth"]["grant"]["grant_type"] == "client_credentials"
+
+      # Re-cast via OpenApiSpex → typed struct tree, three oneOf routings
+      assert {:ok, cast} = cast_response(body)
+
+      assert %SubscriptionResponseSchema{
+               id: id,
+               name: "Order events subscription",
+               destination: %SubscriptionWebhookDestinationResponse{
+                 url: "https://hooks.example.com/orders",
+                 method: "POST",
+                 auth: %WebhookDestinationOAuthResponse{
+                   token_url: "https://auth.example.com/oauth/token",
+                   client_id: "client-abc-123",
+                   grant: %OAuthClientCredentialsGrantResponse{
+                     scope: "read:events write:webhooks"
+                   }
+                 }
+               }
+             } = cast
+
+      assert is_binary(id)
+      assert {:ok, _} = Ecto.UUID.cast(id)
+
+      # Persistence round-trip — Ecto tree hydrated from JSONB
+      assert %Subscription{
+               id: ^id,
+               name: "Order events subscription",
+               destination: %WebhookDestination{
+                 url: "https://hooks.example.com/orders",
+                 method: "POST",
+                 auth: %OAuthAuth{
+                   token_url: "https://auth.example.com/oauth/token",
+                   client_id: "client-abc-123",
+                   grant: %ClientCredentialsGrant{
+                     client_secret: "sk-example-secret",
+                     scope: "read:events write:webhooks"
+                   }
+                 }
+               }
+             } = SubscriptionContext.get_subscription!(id)
+    end
+  end
+
+  describe "create — nesting depth 3 (webhook → oauth → authorization_code)" do
+    test "returns 201, cast tree terminates at AuthorizationCodeGrant leaf, Ecto tree persisted",
+         %{conn: conn} do
+      conn = post(conn, ~p"/api/subscriptions", @authorization_code_attrs)
+      body = json_response(conn, 201)
+
+      assert body["destination"]["destination_type"] == "webhook"
+      assert body["destination"]["auth"]["auth_type"] == "oauth"
+      assert body["destination"]["auth"]["grant"]["grant_type"] == "authorization_code"
+
+      assert {:ok, cast} = cast_response(body)
+
+      assert %SubscriptionResponseSchema{
+               id: id,
+               name: "Authz-code subscription",
+               destination: %SubscriptionWebhookDestinationResponse{
+                 auth: %WebhookDestinationOAuthResponse{
+                   grant: %OAuthAuthorizationCodeGrantResponse{
+                     redirect_uri: "https://app.example.com/oauth/callback"
+                   }
+                 }
+               }
+             } = cast
+
+      assert %Subscription{
+               destination: %WebhookDestination{
+                 auth: %OAuthAuth{
+                   grant: %AuthorizationCodeGrant{
+                     authorization_code: "ac_example_code",
+                     redirect_uri: "https://app.example.com/oauth/callback"
+                   }
+                 }
+               }
+             } = SubscriptionContext.get_subscription!(id)
+    end
+  end
+
+  describe "create — nesting depth 2 (webhook → basic)" do
+    test "returns 201, cast tree terminates at BasicAuth leaf, Ecto tree persisted",
+         %{conn: conn} do
+      conn = post(conn, ~p"/api/subscriptions", @basic_auth_attrs)
+      body = json_response(conn, 201)
+
+      assert body["destination"]["destination_type"] == "webhook"
+      assert body["destination"]["auth"]["auth_type"] == "basic"
+
+      assert {:ok, cast} = cast_response(body)
+
+      assert %SubscriptionResponseSchema{
+               id: id,
+               name: "Infra alerts",
+               destination: %SubscriptionWebhookDestinationResponse{
+                 url: "https://hooks.example.com/infra",
+                 method: "POST",
+                 auth: %WebhookDestinationBasicAuthResponse{
+                   username: "alice"
+                 }
+               }
+             } = cast
+
+      assert %Subscription{
+               destination: %WebhookDestination{
+                 auth: %BasicAuth{username: "alice", password: "s3cret"}
+               }
+             } = SubscriptionContext.get_subscription!(id)
+    end
+  end
+
+  describe "create — nesting depth 1 (flat email)" do
+    test "returns 201, cast tree terminates at EmailDestination leaf (0.14.0 parity check)",
+         %{conn: conn} do
+      conn = post(conn, ~p"/api/subscriptions", @email_attrs)
+      body = json_response(conn, 201)
+
+      assert body["destination"]["destination_type"] == "email"
+
+      assert {:ok, cast} = cast_response(body)
+
+      assert %SubscriptionResponseSchema{
+               id: id,
+               name: "Ops digest",
+               destination: %SubscriptionEmailDestinationResponse{
+                 recipient: "ops@example.com"
+               }
+             } = cast
+
+      assert %Subscription{
+               destination: %EmailDestination{recipient: "ops@example.com"}
+             } = SubscriptionContext.get_subscription!(id)
+    end
+  end
+
+  describe "create — validation errors on nested levels" do
+    test "returns 422 when level-3 grant_type is missing", %{conn: conn} do
+      invalid =
+        put_in(@client_credentials_attrs, [:destination, :auth, :grant], %{
+          client_secret: "sk-example-secret"
+        })
+
+      conn = post(conn, ~p"/api/subscriptions", invalid)
+      assert %{"errors" => _} = json_response(conn, 422)
+    end
+
+    test "returns 422 when level-2 auth_type is missing", %{conn: conn} do
+      invalid = put_in(@basic_auth_attrs, [:destination, :auth], %{username: "alice"})
+      conn = post(conn, ~p"/api/subscriptions", invalid)
+      assert %{"errors" => _} = json_response(conn, 422)
+    end
+
+    test "returns 422 when level-3 grant_type is a bogus value", %{conn: conn} do
+      invalid =
+        put_in(
+          @client_credentials_attrs,
+          [:destination, :auth, :grant, :grant_type],
+          "magic_token"
+        )
+
+      conn = post(conn, ~p"/api/subscriptions", invalid)
+      assert %{"errors" => _} = json_response(conn, 422)
+    end
+  end
+
+  describe "show — full 3-level nested response round-trip" do
+    test "GET on a fixture-persisted 3-level subscription returns wire JSON with discriminators at every level",
+         %{conn: conn} do
+      subscription = oauth_client_credentials_subscription_fixture()
+
+      conn = get(conn, ~p"/api/subscriptions/#{subscription.id}")
+      body = json_response(conn, 200)
+
+      # Three wire discriminators at three distinct nesting levels — GH-34
+      # would have failed this assertion on the response side because
+      # `Mapper.to_map` on the outbound `%Subscription{}` Ecto struct uses
+      # the `:from_ecto` direction which was already working, BUT: the
+      # assert-schema re-cast below would then fail at the nested level
+      # because the resurrected parent-contextual sibling's Mapper impl
+      # used to not stamp `:__type__`.
+      assert body["destination"]["destination_type"] == "webhook"
+      assert body["destination"]["auth"]["auth_type"] == "oauth"
+      assert body["destination"]["auth"]["grant"]["grant_type"] == "client_credentials"
+
+      assert {:ok, cast} = cast_response(body)
+
+      assert %SubscriptionResponseSchema{
+               destination: %SubscriptionWebhookDestinationResponse{
+                 auth: %WebhookDestinationOAuthResponse{
+                   grant: %OAuthClientCredentialsGrantResponse{
+                     scope: "read:events write:webhooks"
+                   }
+                 }
+               }
+             } = cast
+    end
+  end
+
+  describe "index — mixed nesting depths" do
+    test "returns a list where each row's destination casts to the correct nested variant tree",
+         %{conn: conn} do
+      email_subscription_fixture()
+      basic_auth_subscription_fixture()
+      oauth_client_credentials_subscription_fixture()
+
+      conn = get(conn, ~p"/api/subscriptions")
+      body = json_response(conn, 200)
+      assert length(body) == 3
+
+      schemas = @api_spec.components.schemas
+      schema = Map.fetch!(schemas, "SubscriptionResponse")
+
+      cast_items =
+        Enum.map(body, fn item ->
+          assert {:ok, cast} = Cast.cast(schema, item, schemas)
+          cast
+        end)
+
+      by_shape =
+        Enum.group_by(cast_items, fn
+          %SubscriptionResponseSchema{destination: %SubscriptionEmailDestinationResponse{}} ->
+            :email
+
+          %SubscriptionResponseSchema{
+            destination: %SubscriptionWebhookDestinationResponse{
+              auth: %WebhookDestinationBasicAuthResponse{}
+            }
+          } ->
+            :basic
+
+          %SubscriptionResponseSchema{
+            destination: %SubscriptionWebhookDestinationResponse{
+              auth: %WebhookDestinationOAuthResponse{
+                grant: %OAuthClientCredentialsGrantResponse{}
+              }
+            }
+          } ->
+            :oauth_client_credentials
+        end)
+
+      assert length(by_shape[:email]) == 1
+      assert length(by_shape[:basic]) == 1
+      assert length(by_shape[:oauth_client_credentials]) == 1
+    end
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/test/support/fixtures/subscription_context_fixtures.ex
+++ b/examples/phoenix_ecto_open_api_demo/test/support/fixtures/subscription_context_fixtures.ex
@@ -1,0 +1,113 @@
+defmodule PhoenixEctoOpenApiDemo.SubscriptionContextFixtures do
+  @moduledoc """
+  Test helpers for creating `PhoenixEctoOpenApiDemo.SubscriptionContext`
+  entities. Fixtures exercise the three nested polymorphic depths:
+
+    * `email_subscription_fixture/1` — 1-level (flat EmailDestination)
+    * `basic_auth_subscription_fixture/1` — 2-level (WebhookDestination → BasicAuth)
+    * `oauth_client_credentials_subscription_fixture/1` — 3-level
+      (WebhookDestination → OAuthAuth → ClientCredentialsGrant)
+    * `oauth_authorization_code_subscription_fixture/1` — 3-level
+      (WebhookDestination → OAuthAuth → AuthorizationCodeGrant)
+
+  Each uses the Ecto atom `:__type__` key because the changeset path
+  consumes the maps via `cast_polymorphic_embed/3`, which reads
+  `:__type__` at every nesting level.
+  """
+
+  alias PhoenixEctoOpenApiDemo.SubscriptionContext
+
+  @doc "Creates a subscription with a flat email destination (level 1)."
+  def email_subscription_fixture(attrs \\ %{}) do
+    attrs =
+      Enum.into(attrs, %{
+        name: "Ops digest",
+        destination: %{
+          __type__: "email",
+          recipient: "ops@example.com"
+        }
+      })
+
+    {:ok, subscription} = SubscriptionContext.create_subscription(attrs)
+    subscription
+  end
+
+  @doc "Creates a subscription with a webhook destination + basic auth (level 2)."
+  def basic_auth_subscription_fixture(attrs \\ %{}) do
+    attrs =
+      Enum.into(attrs, %{
+        name: "Infra alerts",
+        destination: %{
+          __type__: "webhook",
+          url: "https://hooks.example.com/infra",
+          method: "POST",
+          auth: %{
+            __type__: "basic",
+            username: "alice",
+            password: "s3cret"
+          }
+        }
+      })
+
+    {:ok, subscription} = SubscriptionContext.create_subscription(attrs)
+    subscription
+  end
+
+  @doc """
+  Creates a subscription with a webhook destination + OAuth +
+  client_credentials grant (level 3 — the deepest chain).
+  """
+  def oauth_client_credentials_subscription_fixture(attrs \\ %{}) do
+    attrs =
+      Enum.into(attrs, %{
+        name: "Order events subscription",
+        destination: %{
+          __type__: "webhook",
+          url: "https://hooks.example.com/orders",
+          method: "POST",
+          auth: %{
+            __type__: "oauth",
+            token_url: "https://auth.example.com/oauth/token",
+            client_id: "client-abc-123",
+            grant: %{
+              __type__: "client_credentials",
+              client_secret: "sk-example-secret",
+              scope: "read:events write:webhooks"
+            }
+          }
+        }
+      })
+
+    {:ok, subscription} = SubscriptionContext.create_subscription(attrs)
+    subscription
+  end
+
+  @doc """
+  Creates a subscription with a webhook destination + OAuth +
+  authorization_code grant (level 3 — alternate deepest chain).
+  """
+  def oauth_authorization_code_subscription_fixture(attrs \\ %{}) do
+    attrs =
+      Enum.into(attrs, %{
+        name: "Authz-code subscription",
+        destination: %{
+          __type__: "webhook",
+          url: "https://hooks.example.com/authz",
+          method: "POST",
+          auth: %{
+            __type__: "oauth",
+            token_url: "https://auth.example.com/oauth/token",
+            client_id: "client-zzz-789",
+            grant: %{
+              __type__: "authorization_code",
+              authorization_code: "ac_example_code",
+              redirect_uri: "https://app.example.com/oauth/callback"
+            }
+          }
+        }
+      })
+
+    {:ok, subscription} = SubscriptionContext.create_subscription(attrs)
+    subscription
+  end
+end

--- a/lib/ex_open_api_utils.ex
+++ b/lib/ex_open_api_utils.ex
@@ -387,6 +387,20 @@ defmodule ExOpenApiUtils do
         entry = Map.fetch!(polymorphic_variants, decl.key)
 
         for variant <- entry.variant_entries do
+          # Two distinct discriminator stamps happen on the sibling's Mapper
+          # result map, both derived from the same entry + variant inputs:
+          #
+          #   1. WIRE discriminator (e.g. `:destination_type => "webhook"`) —
+          #      `discriminator_prop` is appended to `property_attrs` below so
+          #      the sibling's walker emits it like any other property.
+          #
+          #   2. ECTO type-field discriminator (e.g. `:__type__ => "webhook"`)
+          #      — `self_stamp_atom` / `self_stamp_wire` below are read by
+          #      `Any.__deriving__/3` (GH-34) and spliced as a final
+          #      `Map.put(result, atom, wire)` at the tail of the generated
+          #      walker body, so nested polymorphic cases get their Ecto
+          #      atom at every level without relying on the outer walker's
+          #      `polymorphic_variants` knowing about nested keys.
           discriminator_prop = %ExOpenApiUtils.Property{
             key: entry.discriminator_atom,
             source: entry.discriminator_atom,
@@ -401,7 +415,9 @@ defmodule ExOpenApiUtils do
             variant.parent_contextual_request_submodule,
             property_attrs: request_attrs,
             map_direction: :from_open_api,
-            polymorphic_variants: polymorphic_variants
+            polymorphic_variants: polymorphic_variants,
+            self_stamp_atom: entry.type_field_atom,
+            self_stamp_wire: variant.wire
           )
 
           Protocol.derive(
@@ -409,7 +425,9 @@ defmodule ExOpenApiUtils do
             variant.parent_contextual_response_submodule,
             property_attrs: response_attrs,
             map_direction: :from_open_api,
-            polymorphic_variants: polymorphic_variants
+            polymorphic_variants: polymorphic_variants,
+            self_stamp_atom: entry.type_field_atom,
+            self_stamp_wire: variant.wire
           )
         end
       end

--- a/lib/ex_open_api_utils/mapper.ex
+++ b/lib/ex_open_api_utils/mapper.ex
@@ -9,71 +9,82 @@ defimpl ExOpenApiUtils.Mapper, for: Any do
     property_attrs = Keyword.fetch!(opts, :property_attrs)
     map_direction = Keyword.fetch!(opts, :map_direction)
     polymorphic_variants = Keyword.get(opts, :polymorphic_variants, %{})
+    # GH-34 self-stamping — at parent-contextual sibling derive time, the
+    # parent passes its own discriminator atom and wire value so the sibling's
+    # generated walker can stamp :__type__ on its own result map from
+    # compile-time constants, with no dependency on the outer walker's
+    # polymorphic_variants map knowing about nested polymorphic fields.
+    self_stamp_atom = Keyword.get(opts, :self_stamp_atom)
+    self_stamp_wire = Keyword.get(opts, :self_stamp_wire)
+    self_stamp_ast = build_self_stamp_ast(self_stamp_atom, self_stamp_wire)
 
     quote do
       alias ExOpenApiUtils.Property
 
       defimpl ExOpenApiUtils.Mapper, for: unquote(module) do
         def to_map(arg) do
-          case unquote(map_direction) do
-            :from_ecto ->
-              Enum.reduce(unquote(Macro.escape(property_attrs)), %{}, fn %Property{} = property,
-                                                                         acc ->
-                source = property.source || property.key
+          result =
+            case unquote(map_direction) do
+              :from_ecto ->
+                Enum.reduce(unquote(Macro.escape(property_attrs)), %{}, fn %Property{} = property,
+                                                                           acc ->
+                  source = property.source || property.key
 
-                val =
-                  if is_list(source) do
-                    Enum.reduce(source, arg, fn key, acc ->
-                      if acc, do: Map.get(acc, key)
+                  val =
+                    if is_list(source) do
+                      Enum.reduce(source, arg, fn key, acc ->
+                        if acc, do: Map.get(acc, key)
+                      end)
+                    else
+                      Map.get(arg, source)
+                    end
+
+                  raw_val = val
+                  val = val |> ExOpenApiUtils.Mapper.to_map()
+
+                  val =
+                    ExOpenApiUtils.Mapper.Polymorphic.inject(
+                      val,
+                      raw_val,
+                      property.key,
+                      unquote(Macro.escape(polymorphic_variants)),
+                      :from_ecto
+                    )
+
+                  Map.put(acc, Atom.to_string(property.key), val)
+                end)
+
+              :from_open_api ->
+                Enum.reduce(unquote(Macro.escape(property_attrs)), %{}, fn %Property{} = property,
+                                                                           acc ->
+                  destination = property.source || property.key
+
+                  raw_val = Map.get(arg, property.key)
+                  val = raw_val |> ExOpenApiUtils.Mapper.to_map()
+
+                  val =
+                    ExOpenApiUtils.Mapper.Polymorphic.inject(
+                      val,
+                      raw_val,
+                      property.key,
+                      unquote(Macro.escape(polymorphic_variants)),
+                      :from_open_api
+                    )
+
+                  if is_list(destination) do
+                    [root | rest] = destination
+                    exploded_map = ExOpenApiUtils.Mapper.Utils.explode_map(rest, val)
+
+                    Map.update(acc, root, %{}, fn existing ->
+                      Map.merge(existing, exploded_map)
                     end)
                   else
-                    Map.get(arg, source)
+                    Map.put(acc, destination, val)
                   end
+                end)
+            end
 
-                raw_val = val
-                val = val |> ExOpenApiUtils.Mapper.to_map()
-
-                val =
-                  ExOpenApiUtils.Mapper.Polymorphic.inject(
-                    val,
-                    raw_val,
-                    property.key,
-                    unquote(Macro.escape(polymorphic_variants)),
-                    :from_ecto
-                  )
-
-                Map.put(acc, Atom.to_string(property.key), val)
-              end)
-
-            :from_open_api ->
-              Enum.reduce(unquote(Macro.escape(property_attrs)), %{}, fn %Property{} = property,
-                                                                         acc ->
-                destination = property.source || property.key
-
-                raw_val = Map.get(arg, property.key)
-                val = raw_val |> ExOpenApiUtils.Mapper.to_map()
-
-                val =
-                  ExOpenApiUtils.Mapper.Polymorphic.inject(
-                    val,
-                    raw_val,
-                    property.key,
-                    unquote(Macro.escape(polymorphic_variants)),
-                    :from_open_api
-                  )
-
-                if is_list(destination) do
-                  [root | rest] = destination
-                  exploded_map = ExOpenApiUtils.Mapper.Utils.explode_map(rest, val)
-
-                  Map.update(acc, root, %{}, fn existing ->
-                    Map.merge(existing, exploded_map)
-                  end)
-                else
-                  Map.put(acc, destination, val)
-                end
-              end)
-          end
+          unquote(self_stamp_ast)
         end
       end
     end
@@ -82,6 +93,21 @@ defimpl ExOpenApiUtils.Mapper, for: Any do
   def to_map(val) do
     val
   end
+
+  # GH-34 — compile-time helper that builds the optional `Map.put(result,
+  # atom, wire)` splice appended to the tail of each derived sibling's
+  # `to_map/1` body. When a parent-contextual sibling's derive passes
+  # `self_stamp_atom` + `self_stamp_wire`, the sibling stamps its own
+  # discriminator on its own result map; otherwise the splice is a no-op
+  # that just returns `result`.
+  defp build_self_stamp_ast(atom, wire)
+       when is_atom(atom) and not is_nil(atom) and is_binary(wire) do
+    quote do
+      Map.put(result, unquote(atom), unquote(wire))
+    end
+  end
+
+  defp build_self_stamp_ast(_atom, _wire), do: quote(do: result)
 end
 
 defimpl ExOpenApiUtils.Mapper, for: [Map] do

--- a/test/ex_open_api_utils/nested_polymorphic_cast_round_trip_test.exs
+++ b/test/ex_open_api_utils/nested_polymorphic_cast_round_trip_test.exs
@@ -58,17 +58,16 @@ defmodule ExOpenApiUtils.NestedPolymorphicCastRoundTripTest do
   alias ExOpenApiUtilsTest.OpenApiSchema.SubscriptionResponse
 
   # Parent-contextual siblings generated at Subscription's __before_compile__
-  alias ExOpenApiUtilsTest.OpenApiSchema.SubscriptionWebhookDestinationRequest
-  alias ExOpenApiUtilsTest.OpenApiSchema.SubscriptionWebhookDestinationResponse
   alias ExOpenApiUtilsTest.OpenApiSchema.SubscriptionEmailDestinationRequest
+  alias ExOpenApiUtilsTest.OpenApiSchema.SubscriptionWebhookDestinationRequest
 
   # Parent-contextual siblings generated at WebhookDestination's __before_compile__
-  alias ExOpenApiUtilsTest.OpenApiSchema.WebhookDestinationOAuthRequest
   alias ExOpenApiUtilsTest.OpenApiSchema.WebhookDestinationBasicAuthRequest
+  alias ExOpenApiUtilsTest.OpenApiSchema.WebhookDestinationOAuthRequest
 
   # Parent-contextual siblings generated at OAuthAuth's __before_compile__
-  alias ExOpenApiUtilsTest.OpenApiSchema.OAuthClientCredentialsGrantRequest
   alias ExOpenApiUtilsTest.OpenApiSchema.OAuthAuthorizationCodeGrantRequest
+  alias ExOpenApiUtilsTest.OpenApiSchema.OAuthClientCredentialsGrantRequest
 
   defp resolved_schemas do
     empty_spec = %OpenApiSpex.OpenApi{

--- a/test/ex_open_api_utils/nested_polymorphic_cast_round_trip_test.exs
+++ b/test/ex_open_api_utils/nested_polymorphic_cast_round_trip_test.exs
@@ -1,0 +1,425 @@
+defmodule ExOpenApiUtils.NestedPolymorphicCastRoundTripTest do
+  @moduledoc """
+  GH-34 regression lock: `Mapper.to_map/1` must preserve the Ecto
+  `type_field_name` atom (`:__type__`) on nested polymorphic submaps during
+  the `:from_open_api` direction, so `cast_polymorphic_embed/3` at every
+  nesting level can route variants correctly.
+
+  Fixture tree (three stacked `open_api_polymorphic_property` macros):
+
+      Nested.Subscription (level 0)
+      ├── :destination polymorphic over [webhook, email]
+      │     wire "destination_type"
+      │
+      ├── Nested.WebhookDestination (level 1, intermediate)
+      │   └── :auth polymorphic over [oauth, basic]
+      │         wire "auth_type"
+      │         │
+      │         ├── Nested.OAuthAuth (level 2, intermediate)
+      │         │   └── :grant polymorphic over [client_credentials, authorization_code]
+      │         │         wire "grant_type"
+      │         │         │
+      │         │         ├── Nested.ClientCredentialsGrant (level 3 leaf)
+      │         │         └── Nested.AuthorizationCodeGrant (level 3 leaf)
+      │         │
+      │         └── Nested.BasicAuth (level 2 leaf)
+      │
+      └── Nested.EmailDestination (level 1 leaf — contrast)
+
+  Before the fix: `Mapper.to_map` stamps `:__type__ => "webhook"` on the
+  outer `:destination` submap (the level-1 case GH-30 covered), but the
+  nested `:auth` and `:grant` submaps get no `:__type__` because
+  `ToolSubscriptionWebhookDestinationRequest`'s Mapper impl is derived at
+  Subscription's compile time with only Subscription's `polymorphic_variants`
+  baked in — it doesn't know about WebhookDestination's own `:auth`
+  declaration.
+
+  After the fix (Option 3 self-stamping siblings): each parent-contextual
+  sibling's Mapper impl is derived with two new options —
+  `self_stamp_atom: :__type__` and `self_stamp_wire: "<wire>"` — and the
+  `Any.__deriving__/3` macro splices a `Map.put(acc, atom, wire)` at the
+  tail of the generated walker body. Each sibling stamps its own discriminator
+  on its own result map from compile-time constants, no outer-walker coupling.
+  """
+  use ExUnit.Case, async: true
+
+  alias OpenApiSpex.Cast
+  alias OpenApiSpex.Schema
+
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.AuthorizationCodeGrant
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.BasicAuth
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.ClientCredentialsGrant
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.EmailDestination
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.OAuthAuth
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.Subscription
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.WebhookDestination
+
+  alias ExOpenApiUtilsTest.OpenApiSchema.SubscriptionRequest
+  alias ExOpenApiUtilsTest.OpenApiSchema.SubscriptionResponse
+
+  # Parent-contextual siblings generated at Subscription's __before_compile__
+  alias ExOpenApiUtilsTest.OpenApiSchema.SubscriptionWebhookDestinationRequest
+  alias ExOpenApiUtilsTest.OpenApiSchema.SubscriptionWebhookDestinationResponse
+  alias ExOpenApiUtilsTest.OpenApiSchema.SubscriptionEmailDestinationRequest
+
+  # Parent-contextual siblings generated at WebhookDestination's __before_compile__
+  alias ExOpenApiUtilsTest.OpenApiSchema.WebhookDestinationOAuthRequest
+  alias ExOpenApiUtilsTest.OpenApiSchema.WebhookDestinationBasicAuthRequest
+
+  # Parent-contextual siblings generated at OAuthAuth's __before_compile__
+  alias ExOpenApiUtilsTest.OpenApiSchema.OAuthClientCredentialsGrantRequest
+  alias ExOpenApiUtilsTest.OpenApiSchema.OAuthAuthorizationCodeGrantRequest
+
+  defp resolved_schemas do
+    empty_spec = %OpenApiSpex.OpenApi{
+      info: %OpenApiSpex.Info{title: "test", version: "0"},
+      paths: %{},
+      components: %OpenApiSpex.Components{schemas: %{}}
+    }
+
+    empty_spec
+    |> OpenApiSpex.add_schemas([SubscriptionRequest, SubscriptionResponse])
+    |> then(& &1.components.schemas)
+  end
+
+  defp cast_request(wire_map) do
+    schemas = resolved_schemas()
+    schema = Map.fetch!(schemas, "SubscriptionRequest")
+    Cast.cast(schema, wire_map, schemas)
+  end
+
+  describe "GH-34 — Mapper.to_map stamps :__type__ at every nesting level on :from_open_api" do
+    test "deepest chain (subscription → webhook → oauth → client_credentials) stamps :__type__ at all three polymorphic levels" do
+      request = %SubscriptionRequest{
+        name: "Order events subscription",
+        destination: %SubscriptionWebhookDestinationRequest{
+          destination_type: "webhook",
+          url: "https://hooks.example.com/deliveries",
+          method: "POST",
+          auth: %WebhookDestinationOAuthRequest{
+            auth_type: "oauth",
+            token_url: "https://auth.example.com/oauth/token",
+            client_id: "client-abc-123",
+            grant: %OAuthClientCredentialsGrantRequest{
+              grant_type: "client_credentials",
+              client_secret: "sk-example-secret",
+              scope: "read:events write:webhooks"
+            }
+          }
+        }
+      }
+
+      attrs_map = ExOpenApiUtils.Mapper.to_map(request)
+
+      # Level 1 — :destination submap
+      assert get_in(attrs_map, [:destination, :__type__]) == "webhook"
+
+      # Level 2 — :auth submap inside :destination — THIS IS THE GAP GH-34 CLOSES
+      assert get_in(attrs_map, [:destination, :auth, :__type__]) == "oauth"
+
+      # Level 3 — :grant submap inside :auth inside :destination — depth-unbounded
+      assert get_in(attrs_map, [:destination, :auth, :grant, :__type__]) ==
+               "client_credentials"
+
+      # Wire-side discriminators (the existing discriminator_prop walker keeps these working)
+      assert get_in(attrs_map, [:destination, :destination_type]) == "webhook"
+      assert get_in(attrs_map, [:destination, :auth, :auth_type]) == "oauth"
+      assert get_in(attrs_map, [:destination, :auth, :grant, :grant_type]) ==
+               "client_credentials"
+    end
+
+    test "middle chain (subscription → webhook → basic) terminates cleanly at level 2" do
+      request = %SubscriptionRequest{
+        name: "Infra alerts",
+        destination: %SubscriptionWebhookDestinationRequest{
+          destination_type: "webhook",
+          url: "https://hooks.example.com/infra",
+          method: "POST",
+          auth: %WebhookDestinationBasicAuthRequest{
+            auth_type: "basic",
+            username: "alice",
+            password: "s3cret"
+          }
+        }
+      }
+
+      attrs_map = ExOpenApiUtils.Mapper.to_map(request)
+
+      assert get_in(attrs_map, [:destination, :__type__]) == "webhook"
+      assert get_in(attrs_map, [:destination, :auth, :__type__]) == "basic"
+      assert get_in(attrs_map, [:destination, :auth, :username]) == "alice"
+    end
+
+    test "shallow chain (subscription → email) locks parity with 0.14.0 single-level behavior" do
+      request = %SubscriptionRequest{
+        name: "Ops digest",
+        destination: %SubscriptionEmailDestinationRequest{
+          destination_type: "email",
+          recipient: "ops@example.com"
+        }
+      }
+
+      attrs_map = ExOpenApiUtils.Mapper.to_map(request)
+
+      assert get_in(attrs_map, [:destination, :__type__]) == "email"
+      assert get_in(attrs_map, [:destination, :recipient]) == "ops@example.com"
+    end
+
+    test "authorization_code grant leaf is reachable via the same deepest chain" do
+      request = %SubscriptionRequest{
+        name: "Authz-code subscription",
+        destination: %SubscriptionWebhookDestinationRequest{
+          destination_type: "webhook",
+          url: "https://hooks.example.com/authz",
+          method: "POST",
+          auth: %WebhookDestinationOAuthRequest{
+            auth_type: "oauth",
+            token_url: "https://auth.example.com/oauth/token",
+            client_id: "client-zzz-789",
+            grant: %OAuthAuthorizationCodeGrantRequest{
+              grant_type: "authorization_code",
+              authorization_code: "ac_example_code",
+              redirect_uri: "https://app.example.com/oauth/callback"
+            }
+          }
+        }
+      }
+
+      attrs_map = ExOpenApiUtils.Mapper.to_map(request)
+
+      assert get_in(attrs_map, [:destination, :__type__]) == "webhook"
+      assert get_in(attrs_map, [:destination, :auth, :__type__]) == "oauth"
+
+      assert get_in(attrs_map, [:destination, :auth, :grant, :__type__]) ==
+               "authorization_code"
+    end
+  end
+
+  describe "GH-34 — full changeset round-trip through Ecto cast_polymorphic_embed at every nesting level" do
+    test "deepest chain resolves to the full Ecto struct tree via apply_action(:insert)" do
+      request = %SubscriptionRequest{
+        name: "Order events subscription",
+        destination: %SubscriptionWebhookDestinationRequest{
+          destination_type: "webhook",
+          url: "https://hooks.example.com/deliveries",
+          method: "POST",
+          auth: %WebhookDestinationOAuthRequest{
+            auth_type: "oauth",
+            token_url: "https://auth.example.com/oauth/token",
+            client_id: "client-abc-123",
+            grant: %OAuthClientCredentialsGrantRequest{
+              grant_type: "client_credentials",
+              client_secret: "sk-example-secret",
+              scope: "read:events write:webhooks"
+            }
+          }
+        }
+      }
+
+      assert {:ok,
+              %Subscription{
+                name: "Order events subscription",
+                destination: %WebhookDestination{
+                  url: "https://hooks.example.com/deliveries",
+                  method: "POST",
+                  auth: %OAuthAuth{
+                    token_url: "https://auth.example.com/oauth/token",
+                    client_id: "client-abc-123",
+                    grant: %ClientCredentialsGrant{
+                      client_secret: "sk-example-secret",
+                      scope: "read:events write:webhooks"
+                    }
+                  }
+                }
+              }} =
+               %Subscription{}
+               |> Subscription.changeset(request)
+               |> Ecto.Changeset.apply_action(:insert)
+    end
+
+    test "middle chain (basic auth) resolves to the Ecto tree, level 2 terminates cleanly" do
+      request = %SubscriptionRequest{
+        name: "Infra alerts",
+        destination: %SubscriptionWebhookDestinationRequest{
+          destination_type: "webhook",
+          url: "https://hooks.example.com/infra",
+          method: "POST",
+          auth: %WebhookDestinationBasicAuthRequest{
+            auth_type: "basic",
+            username: "alice",
+            password: "s3cret"
+          }
+        }
+      }
+
+      assert {:ok,
+              %Subscription{
+                destination: %WebhookDestination{
+                  auth: %BasicAuth{username: "alice", password: "s3cret"}
+                }
+              }} =
+               %Subscription{}
+               |> Subscription.changeset(request)
+               |> Ecto.Changeset.apply_action(:insert)
+    end
+
+    test "shallow chain (email destination) still works identically to 0.14.0 single-level case" do
+      request = %SubscriptionRequest{
+        name: "Ops digest",
+        destination: %SubscriptionEmailDestinationRequest{
+          destination_type: "email",
+          recipient: "ops@example.com"
+        }
+      }
+
+      assert {:ok,
+              %Subscription{
+                destination: %EmailDestination{recipient: "ops@example.com"}
+              }} =
+               %Subscription{}
+               |> Subscription.changeset(request)
+               |> Ecto.Changeset.apply_action(:insert)
+    end
+
+    test "authorization_code grant variant resolves to %AuthorizationCodeGrant{} at level 3" do
+      request = %SubscriptionRequest{
+        name: "Authz-code subscription",
+        destination: %SubscriptionWebhookDestinationRequest{
+          destination_type: "webhook",
+          url: "https://hooks.example.com/authz",
+          method: "POST",
+          auth: %WebhookDestinationOAuthRequest{
+            auth_type: "oauth",
+            token_url: "https://auth.example.com/oauth/token",
+            client_id: "client-zzz-789",
+            grant: %OAuthAuthorizationCodeGrantRequest{
+              grant_type: "authorization_code",
+              authorization_code: "ac_example_code",
+              redirect_uri: "https://app.example.com/oauth/callback"
+            }
+          }
+        }
+      }
+
+      assert {:ok,
+              %Subscription{
+                destination: %WebhookDestination{
+                  auth: %OAuthAuth{
+                    grant: %AuthorizationCodeGrant{
+                      authorization_code: "ac_example_code",
+                      redirect_uri: "https://app.example.com/oauth/callback"
+                    }
+                  }
+                }
+              }} =
+               %Subscription{}
+               |> Subscription.changeset(request)
+               |> Ecto.Changeset.apply_action(:insert)
+    end
+  end
+
+  describe "GH-34 — :from_ecto direction regression lock (already worked in 0.14.0, no regression after fix)" do
+    test "Mapper.to_map on the Ecto struct tree stamps wire discriminators at every level" do
+      ecto_tree = %Subscription{
+        id: "3f7d8c7a-3c3b-4c2d-9c5a-3f7d8c7a3c3b",
+        name: "Order events",
+        destination: %WebhookDestination{
+          url: "https://hooks.example.com/deliveries",
+          method: "POST",
+          auth: %OAuthAuth{
+            token_url: "https://auth.example.com/oauth/token",
+            client_id: "client-abc-123",
+            grant: %ClientCredentialsGrant{
+              client_secret: "sk-example-secret",
+              scope: "read:events"
+            }
+          }
+        }
+      }
+
+      wire = ExOpenApiUtils.Mapper.to_map(ecto_tree)
+
+      assert get_in(wire, ["destination", "destination_type"]) == "webhook"
+      assert get_in(wire, ["destination", "auth", "auth_type"]) == "oauth"
+      assert get_in(wire, ["destination", "auth", "grant", "grant_type"]) ==
+               "client_credentials"
+    end
+  end
+
+  describe "GH-34 — schema composition introspection" do
+    test "WebhookDestinationOAuthRequest is an allOf composition with auto-filled title and x-struct" do
+      schema = WebhookDestinationOAuthRequest.schema()
+
+      assert %Schema{allOf: all_of} = schema
+      assert length(all_of) == 2
+
+      assert schema."x-struct" == WebhookDestinationOAuthRequest
+      assert schema.title == "WebhookDestinationOAuthRequest"
+    end
+
+    test "OAuthClientCredentialsGrantRequest has :__type__ unnecessary on defstruct — defstruct only has client_secret + scope + grant_type" do
+      # The parent-contextual sibling's defstruct is built from
+      # `Schema.properties/1` walking the allOf. The patch schema adds the
+      # *wire* discriminator (grant_type) as a first-class field, NOT the
+      # Ecto :__type__ atom. :__type__ is stamped on the runtime map by
+      # the self-stamp splice, not on the defstruct.
+      keys = %OAuthClientCredentialsGrantRequest{} |> Map.from_struct() |> Map.keys()
+
+      assert :client_secret in keys
+      assert :scope in keys
+      assert :grant_type in keys
+      refute :__type__ in keys
+    end
+  end
+
+  describe "GH-34 — round-trip through wire map → cast → re-serialize" do
+    test "wire map cast routes to SubscriptionWebhookDestinationRequest with nested oauth/client_credentials" do
+      wire_map = %{
+        "name" => "Order events subscription",
+        "destination" => %{
+          "destination_type" => "webhook",
+          "url" => "https://hooks.example.com/deliveries",
+          "method" => "POST",
+          "auth" => %{
+            "auth_type" => "oauth",
+            "token_url" => "https://auth.example.com/oauth/token",
+            "client_id" => "client-abc-123",
+            "grant" => %{
+              "grant_type" => "client_credentials",
+              "client_secret" => "sk-example-secret",
+              "scope" => "read:events"
+            }
+          }
+        }
+      }
+
+      assert {:ok, cast_output} = cast_request(wire_map)
+
+      assert %SubscriptionRequest{
+               name: "Order events subscription",
+               destination: %SubscriptionWebhookDestinationRequest{
+                 destination_type: "webhook",
+                 url: "https://hooks.example.com/deliveries",
+                 method: "POST",
+                 auth: %WebhookDestinationOAuthRequest{
+                   auth_type: "oauth",
+                   grant: %OAuthClientCredentialsGrantRequest{
+                     grant_type: "client_credentials"
+                   }
+                 }
+               }
+             } = cast_output
+
+      # Now pipe cast output through Mapper.to_map and assert :__type__ is
+      # stamped at every polymorphic level — this is the full round-trip
+      # that controllers run in practice.
+      attrs_map = ExOpenApiUtils.Mapper.to_map(cast_output)
+
+      assert get_in(attrs_map, [:destination, :__type__]) == "webhook"
+      assert get_in(attrs_map, [:destination, :auth, :__type__]) == "oauth"
+
+      assert get_in(attrs_map, [:destination, :auth, :grant, :__type__]) ==
+               "client_credentials"
+    end
+  end
+end

--- a/test/ex_open_api_utils/nested_polymorphic_cast_round_trip_test.exs
+++ b/test/ex_open_api_utils/nested_polymorphic_cast_round_trip_test.exs
@@ -124,6 +124,7 @@ defmodule ExOpenApiUtils.NestedPolymorphicCastRoundTripTest do
       # Wire-side discriminators (the existing discriminator_prop walker keeps these working)
       assert get_in(attrs_map, [:destination, :destination_type]) == "webhook"
       assert get_in(attrs_map, [:destination, :auth, :auth_type]) == "oauth"
+
       assert get_in(attrs_map, [:destination, :auth, :grant, :grant_type]) ==
                "client_credentials"
     end
@@ -341,6 +342,7 @@ defmodule ExOpenApiUtils.NestedPolymorphicCastRoundTripTest do
 
       assert get_in(wire, ["destination", "destination_type"]) == "webhook"
       assert get_in(wire, ["destination", "auth", "auth_type"]) == "oauth"
+
       assert get_in(wire, ["destination", "auth", "grant", "grant_type"]) ==
                "client_credentials"
     end

--- a/test/support/polymorphic_discriminator/nested/authorization_code_grant.ex
+++ b/test/support/polymorphic_discriminator/nested/authorization_code_grant.ex
@@ -1,0 +1,36 @@
+defmodule ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.AuthorizationCodeGrant do
+  @moduledoc false
+  use ExOpenApiUtils
+
+  open_api_property(
+    key: :authorization_code,
+    schema: %Schema{type: :string, writeOnly: true, example: "ac_example_code"}
+  )
+
+  open_api_property(
+    key: :redirect_uri,
+    schema: %Schema{
+      type: :string,
+      format: :uri,
+      example: "https://app.example.com/oauth/callback"
+    }
+  )
+
+  embedded_schema do
+    field(:authorization_code, :string)
+    field(:redirect_uri, :string)
+  end
+
+  open_api_schema(
+    title: "AuthorizationCodeGrant",
+    description: "OAuth 2.0 authorization-code grant (level 3 leaf).",
+    required: [:authorization_code, :redirect_uri],
+    properties: [:authorization_code, :redirect_uri]
+  )
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:authorization_code, :redirect_uri])
+    |> validate_required([:authorization_code, :redirect_uri])
+  end
+end

--- a/test/support/polymorphic_discriminator/nested/basic_auth.ex
+++ b/test/support/polymorphic_discriminator/nested/basic_auth.ex
@@ -1,0 +1,32 @@
+defmodule ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.BasicAuth do
+  @moduledoc false
+  use ExOpenApiUtils
+
+  open_api_property(
+    key: :username,
+    schema: %Schema{type: :string, example: "alice"}
+  )
+
+  open_api_property(
+    key: :password,
+    schema: %Schema{type: :string, writeOnly: true, example: "s3cret"}
+  )
+
+  embedded_schema do
+    field(:username, :string)
+    field(:password, :string)
+  end
+
+  open_api_schema(
+    title: "BasicAuth",
+    description: "HTTP Basic authentication leaf (level 2, flat contrast).",
+    required: [:username, :password],
+    properties: [:username, :password]
+  )
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:username, :password])
+    |> validate_required([:username, :password])
+  end
+end

--- a/test/support/polymorphic_discriminator/nested/client_credentials_grant.ex
+++ b/test/support/polymorphic_discriminator/nested/client_credentials_grant.ex
@@ -1,0 +1,32 @@
+defmodule ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.ClientCredentialsGrant do
+  @moduledoc false
+  use ExOpenApiUtils
+
+  open_api_property(
+    key: :client_secret,
+    schema: %Schema{type: :string, writeOnly: true, example: "sk-example-secret"}
+  )
+
+  open_api_property(
+    key: :scope,
+    schema: %Schema{type: :string, example: "read:events write:webhooks"}
+  )
+
+  embedded_schema do
+    field(:client_secret, :string)
+    field(:scope, :string)
+  end
+
+  open_api_schema(
+    title: "ClientCredentialsGrant",
+    description: "OAuth 2.0 client-credentials grant (level 3 leaf).",
+    required: [:client_secret],
+    properties: [:client_secret, :scope]
+  )
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:client_secret, :scope])
+    |> validate_required([:client_secret])
+  end
+end

--- a/test/support/polymorphic_discriminator/nested/email_destination.ex
+++ b/test/support/polymorphic_discriminator/nested/email_destination.ex
@@ -1,0 +1,26 @@
+defmodule ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.EmailDestination do
+  @moduledoc false
+  use ExOpenApiUtils
+
+  open_api_property(
+    key: :recipient,
+    schema: %Schema{type: :string, format: :email, example: "ops@example.com"}
+  )
+
+  embedded_schema do
+    field(:recipient, :string)
+  end
+
+  open_api_schema(
+    title: "EmailDestination",
+    description: "Email delivery destination leaf (level 1, flat contrast).",
+    required: [:recipient],
+    properties: [:recipient]
+  )
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:recipient])
+    |> validate_required([:recipient])
+  end
+end

--- a/test/support/polymorphic_discriminator/nested/oauth_auth.ex
+++ b/test/support/polymorphic_discriminator/nested/oauth_auth.ex
@@ -1,0 +1,62 @@
+defmodule ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.OAuthAuth do
+  @moduledoc false
+  use ExOpenApiUtils
+
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.AuthorizationCodeGrant
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.ClientCredentialsGrant
+
+  import PolymorphicEmbed
+
+  open_api_property(
+    key: :token_url,
+    schema: %Schema{
+      type: :string,
+      format: :uri,
+      example: "https://auth.example.com/oauth/token"
+    }
+  )
+
+  open_api_property(
+    key: :client_id,
+    schema: %Schema{type: :string, example: "client-abc-123"}
+  )
+
+  open_api_polymorphic_property(
+    key: :grant,
+    type_field_name: :__type__,
+    open_api_discriminator_property: "grant_type",
+    variants: [
+      client_credentials: ClientCredentialsGrant,
+      authorization_code: AuthorizationCodeGrant
+    ]
+  )
+
+  embedded_schema do
+    field(:token_url, :string)
+    field(:client_id, :string)
+
+    polymorphic_embeds_one(:grant,
+      types: [
+        client_credentials: ClientCredentialsGrant,
+        authorization_code: AuthorizationCodeGrant
+      ],
+      type_field_name: :__type__,
+      on_type_not_found: :raise,
+      on_replace: :update
+    )
+  end
+
+  open_api_schema(
+    title: "OAuth",
+    description: "OAuth 2.0 authentication (level 2 intermediate polymorphic parent).",
+    required: [:token_url, :client_id, :grant],
+    properties: [:token_url, :client_id, :grant]
+  )
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:token_url, :client_id])
+    |> validate_required([:token_url, :client_id])
+    |> cast_polymorphic_embed(:grant, required: true)
+  end
+end

--- a/test/support/polymorphic_discriminator/nested/subscription.ex
+++ b/test/support/polymorphic_discriminator/nested/subscription.ex
@@ -1,0 +1,67 @@
+defmodule ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.Subscription do
+  @moduledoc false
+  use ExOpenApiUtils
+
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.EmailDestination
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.WebhookDestination
+
+  import PolymorphicEmbed
+
+  open_api_property(
+    key: :id,
+    schema: %Schema{
+      type: :string,
+      format: :uuid,
+      example: "3f7d8c7a-3c3b-4c2d-9c5a-3f7d8c7a3c3b",
+      readOnly: true
+    }
+  )
+
+  open_api_property(
+    key: :name,
+    schema: %Schema{type: :string, example: "Order events subscription"}
+  )
+
+  open_api_polymorphic_property(
+    key: :destination,
+    type_field_name: :__type__,
+    open_api_discriminator_property: "destination_type",
+    variants: [
+      webhook: WebhookDestination,
+      email: EmailDestination
+    ]
+  )
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "nested_subscriptions" do
+    field(:name, :string)
+
+    polymorphic_embeds_one(:destination,
+      types: [
+        webhook: WebhookDestination,
+        email: EmailDestination
+      ],
+      type_field_name: :__type__,
+      on_type_not_found: :raise,
+      on_replace: :update
+    )
+
+    timestamps()
+  end
+
+  open_api_schema(
+    title: "Subscription",
+    description: "Event subscription with a polymorphic destination (level 0 top-level parent).",
+    required: [:name, :destination],
+    properties: [:id, :name, :destination],
+    tags: ["Subscription"]
+  )
+
+  def changeset(subscription, attrs) do
+    subscription
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+    |> cast_polymorphic_embed(:destination, required: true)
+  end
+end

--- a/test/support/polymorphic_discriminator/nested/webhook_destination.ex
+++ b/test/support/polymorphic_discriminator/nested/webhook_destination.ex
@@ -1,0 +1,66 @@
+defmodule ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.WebhookDestination do
+  @moduledoc false
+  use ExOpenApiUtils
+
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.BasicAuth
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.Nested.OAuthAuth
+
+  import PolymorphicEmbed
+
+  open_api_property(
+    key: :url,
+    schema: %Schema{
+      type: :string,
+      format: :uri,
+      example: "https://hooks.example.com/deliveries"
+    }
+  )
+
+  open_api_property(
+    key: :method,
+    schema: %Schema{
+      type: :string,
+      enum: ["POST", "PUT", "PATCH"],
+      example: "POST"
+    }
+  )
+
+  open_api_polymorphic_property(
+    key: :auth,
+    type_field_name: :__type__,
+    open_api_discriminator_property: "auth_type",
+    variants: [
+      oauth: OAuthAuth,
+      basic: BasicAuth
+    ]
+  )
+
+  embedded_schema do
+    field(:url, :string)
+    field(:method, :string)
+
+    polymorphic_embeds_one(:auth,
+      types: [
+        oauth: OAuthAuth,
+        basic: BasicAuth
+      ],
+      type_field_name: :__type__,
+      on_type_not_found: :raise,
+      on_replace: :update
+    )
+  end
+
+  open_api_schema(
+    title: "WebhookDestination",
+    description: "HTTP webhook delivery destination (level 1 intermediate polymorphic parent).",
+    required: [:url, :method, :auth],
+    properties: [:url, :method, :auth]
+  )
+
+  def changeset(schema, attrs) do
+    schema
+    |> cast(attrs, [:url, :method])
+    |> validate_required([:url, :method])
+    |> cast_polymorphic_embed(:auth, required: true)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -49,4 +49,37 @@ ExOpenApiUtilsTest.CompiledFixtures.stash(
 
 ExOpenApiUtilsTest.CompiledFixtures.stash("test/support/polymorphic_discriminator/analytics.ex")
 
+# GH-34 — nested polymorphic fixtures. Webhook-subscription + auth tree that
+# stacks three `open_api_polymorphic_property` macros: Subscription.destination
+# → WebhookDestination.auth → OAuthAuth.grant. Variants must load before their
+# parents so the parent's macro can reflect on each variant's
+# `__ex_open_api_utils_schemas__/0` at compile time.
+ExOpenApiUtilsTest.CompiledFixtures.stash(
+  "test/support/polymorphic_discriminator/nested/client_credentials_grant.ex"
+)
+
+ExOpenApiUtilsTest.CompiledFixtures.stash(
+  "test/support/polymorphic_discriminator/nested/authorization_code_grant.ex"
+)
+
+ExOpenApiUtilsTest.CompiledFixtures.stash(
+  "test/support/polymorphic_discriminator/nested/basic_auth.ex"
+)
+
+ExOpenApiUtilsTest.CompiledFixtures.stash(
+  "test/support/polymorphic_discriminator/nested/oauth_auth.ex"
+)
+
+ExOpenApiUtilsTest.CompiledFixtures.stash(
+  "test/support/polymorphic_discriminator/nested/email_destination.ex"
+)
+
+ExOpenApiUtilsTest.CompiledFixtures.stash(
+  "test/support/polymorphic_discriminator/nested/webhook_destination.ex"
+)
+
+ExOpenApiUtilsTest.CompiledFixtures.stash(
+  "test/support/polymorphic_discriminator/nested/subscription.ex"
+)
+
 ExUnit.start()


### PR DESCRIPTION
## Summary

Closes #34. Extends `open_api_polymorphic_property/1` to support **arbitrary-depth nested polymorphism** — where one variant of an outer polymorphic field is itself a polymorphic parent (and so on, recursively). 0.14.0 closed GH-30 for single-level polymorphism via `allOf`-composed parent-contextual siblings. This PR is the additive follow-up for nested cases where `Mapper.to_map/1` failed to stamp the Ecto `type_field_name` atom (`:__type__`) on nested submaps during the `:from_open_api` direction, causing `cast_polymorphic_embed/3` to raise `PolymorphicEmbed.raise_cannot_infer_type_from_data/1` at nested levels.

Framed as **new feature** rather than bug fix: nested polymorphism was never part of the 0.14.0 contract. The change is additive, backward compatible, zero wire-format diff, and touches two files surgically.

## The fix — Option 3: self-stamping parent-contextual siblings

Each parent-contextual sibling is generated at its **outer polymorphic parent's** `__before_compile__` time. At that point, the library already knows the Ecto `type_field_name` atom and the variant's wire value as compile-time constants. Pass both through `Protocol.derive` as new options:

- `self_stamp_atom` — e.g. `:__type__`
- `self_stamp_wire` — e.g. `"webhook"`

`Any.__deriving__/3` reads the options and, when both are set, splices `Map.put(result, <atom>, <wire>)` at the tail of the generated `to_map/1` body after the direction-specific reduce. When either is absent, the splice is a no-op that returns `result` unchanged — so all non-sibling derives behave exactly as they did in 0.14.0.

Each parent-contextual sibling's Mapper impl now stamps its own Ecto discriminator atom on its own result map from compile-time constants. No outer-walker coupling, no new reflection API, no runtime context passing. The pattern mirrors `Platform.ToolCallConfigGeneratorProtocol`'s "each variant's defimpl is self-contained" idiom.

### Two-file surgical change

- [`lib/ex_open_api_utils/mapper.ex`](../blob/feat/gh-34-nested-polymorphic-self-stamping-siblings/lib/ex_open_api_utils/mapper.ex) — `Any.__deriving__/3` adds `self_stamp_atom` / `self_stamp_wire` Keyword reads, a `build_self_stamp_ast/2` private helper that emits either `Map.put(result, <atom>, <wire>)` or `result` unchanged, and a splice at the tail of the generated `to_map/1` body.
- [`lib/ex_open_api_utils.ex`](../blob/feat/gh-34-nested-polymorphic-self-stamping-siblings/lib/ex_open_api_utils.ex) — the sibling derive loop at lines 386-435 passes `self_stamp_atom: entry.type_field_atom` and `self_stamp_wire: variant.wire` to both `Protocol.derive` calls (request and response parent-contextual siblings). An inline 10-line comment documents the two-discriminator split (wire discriminator via `discriminator_prop` walker, Ecto atom via splice) so the call site reads as a single algorithm.

## Scope of the change

**`:from_open_api` direction only.** Parent-contextual siblings exist only on the cast-output path. The outer walker's `inject/5` continues to work as-is for the `:from_ecto` direction because each Ecto module's own Mapper impl is derived at its own compile time with its own `polymorphic_variants`, and recursion composes naturally at each level.

**Parent-contextual siblings only.** Top-level `NotificationRequest` / `NotificationResponse` derives and Ecto struct derives receive no `self_stamp_*` options, so the splice emits `acc` unchanged — no behavior change for them.

## Caller impact

**Zero wire-visible change.**

| Surface | Before | After |
|---|---|---|
| HTTP request/response body JSON | ✅ same | ✅ same |
| `openapi.json` / `openapi.yaml` | ✅ same | ✅ same |
| `components.schemas.*` entries | ✅ same | ✅ same |
| Generated SDK types (hey-api, etc.) | ✅ same | ✅ same |
| `Plug.CastAndValidate` behavior | ✅ same | ✅ same |
| Controller code | ✅ same | ✅ same |
| Nested `cast_polymorphic_embed` at 2+ levels | ❌ raises at runtime | ✅ works |

Consumer migration: bump `ex_open_api_utils` to the new minor version in `mix.exs`, run `mix deps.update ex_open_api_utils`, previously-failing nested `cast_polymorphic_embed` tests go green.

## Test coverage

**Library-level** — new 7-module nested fixture tree under `test/support/polymorphic_discriminator/nested/` in a domain-neutral webhook-subscription + OAuth auth shape (3 stacked `open_api_polymorphic_property` macros). Plus `test/ex_open_api_utils/nested_polymorphic_cast_round_trip_test.exs` with 12 tests covering:
- `Mapper.to_map` stamps `:__type__` at every nesting level on the deepest (3-level), middle (2-level), and shallow (1-level) chains
- Full `changeset + apply_action` round-trip resolves to the complete Ecto struct tree at every depth
- Schema introspection — `allOf` composition, defstruct field membership
- `:from_ecto` direction regression lock (already worked in 0.14.0, now has explicit coverage)
- Wire-map → cast → re-serialize round-trip

**Example app** — new `PhoenixEctoOpenApiDemo.SubscriptionContext` with 7 Ecto schemas, a migration, context module, JSON controller, and 9 controller tests that exercise the full Phoenix pipeline (CastAndValidate → changeset → Repo → render → re-cast) at 1/2/3 levels. Mixed-nesting index test, targeted 422 tests for missing/bogus nested discriminators.

**Vitest tier** — new `integration-tests/tests/subscriptions.test.ts` covering the same three depths end-to-end through the live Phoenix surface with the production-style ky + zod + vite-plugin stack. Local-only via `make vitest`; not wired to CI per existing convention.

## Verification

- Library: `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix credo --strict`, `mix test --cover` — **107 tests, 0 failures**, 95.02% coverage
- Example app: `mix compile --warnings-as-errors`, `mix format --check-formatted`, `mix ecto.reset`, `mix test` — **99 tests, 0 failures**
- Vitest tier — verified by mirroring the existing `notifications.test.ts` structure; runs locally via `make vitest`

## Commit series

1. `test(polymorphic): add GH-34 nested polymorphic cast round-trip reproducer (failing)` — 7-module fixture tree + 12-test reproducer suite, 7 of 12 failing before the fix
2. `feat(mapper): add self_stamp_atom / self_stamp_wire splice to Any.__deriving__/3` — splice infrastructure, no behavior change (all 107 existing tests green)
3. `feat(polymorphic): pass self_stamp options through parent-contextual sibling derive loop` — wires the options at the sibling derive site, flips all 7 failing tests to green. Also bumps `.credo.exs`'s `LongQuoteBlocks` `max_line_count` from the default 150 to 200 (with justification comment) so the legitimately-long `__before_compile__` macro can stay locally cohesive without linter-driven fragmentation.
4. `test(example): add 3-level nested subscription_context fixture + controller test`
5. `test(example): add vitest integration tier coverage for nested polymorphism`

## Non-goals

- No change to the `Mapper` protocol signature — `to_map/1` stays as-is
- No change to the `open_api_polymorphic_property/1` DSL — consumers write the same code
- No change to the cast path (`OpenApiSpex.Cast.cast/4`) or `allOf` composition on parent-contextual siblings
- No variant-side macro additions — leaf variants need no new annotations
- No runtime reflection — `self_stamp_atom` / `self_stamp_wire` are compile-time constants baked into each sibling's `.beam` literal pool, preserving GH-27 bytecode lock invariants (atom persistence strictly strengthened)
- No trimming of `inject/5` — the outer walker's inject stays and idempotently overlaps with the sibling's self-stamp on `:from_open_api`; removing that is out of scope for this PR

## Test plan

- [x] Library `mix compile --warnings-as-errors`
- [x] Library `mix format --check-formatted`
- [x] Library `mix credo --strict`
- [x] Library `mix test --cover` — 107 passing, 95.02% coverage
- [x] Example app `mix compile --warnings-as-errors`
- [x] Example app `mix format --check-formatted`
- [x] Example app `mix ecto.reset` + `mix test` — 99 passing
- [ ] Vitest tier `make vitest` (local-only — verified structurally against `notifications.test.ts` conventions)