### PR TITLE
fix(polymorphic): dedupe parent-contextual siblings across embeds sharing a variant set (#47)

### DIFF
--- a/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/notification_context/dual_channel_notification.ex
+++ b/examples/phoenix_ecto_open_api_demo/lib/phoenix_ecto_open_api_demo/notification_context/dual_channel_notification.ex
@@ -1,0 +1,100 @@
+defmodule PhoenixEctoOpenApiDemo.NotificationContext.DualChannelNotification do
+  @moduledoc """
+  GH-47 example. A parent schema with **two** `open_api_polymorphic_property/1`
+  declarations that share the same variant pool (`Email` / `Sms` / `Webhook`).
+
+  Before the GH-47 fix, this pattern blocked compilation under
+  `--warnings-as-errors` because both decls derived identically-named
+  parent-contextual sibling modules (`DualChannelNotificationEmailRequest`,
+  etc.) — `Module.create/3` and `Protocol.derive/3` were called twice for
+  each target, emitting "redefining module" warnings. The library now
+  dedupes these calls when the generated bodies are structurally identical
+  (and raises a `CompileError` when they would disagree).
+
+  Use case: a notification that delivers via a `primary_channel` and falls
+  back to a `fallback_channel` if the primary fails — both legitimately
+  draw from the same provider set.
+  """
+  use ExOpenApiUtils
+
+  alias PhoenixEctoOpenApiDemo.NotificationContext.Email
+  alias PhoenixEctoOpenApiDemo.NotificationContext.Sms
+  alias PhoenixEctoOpenApiDemo.NotificationContext.Webhook
+
+  import PolymorphicEmbed
+
+  open_api_property(
+    key: :id,
+    schema: %Schema{
+      type: :string,
+      format: :uuid,
+      example: "851b18d7-0c88-4095-9969-cbe385926420",
+      readOnly: true
+    }
+  )
+
+  open_api_property(
+    key: :subject,
+    schema: %Schema{type: :string, example: "Your order has shipped"}
+  )
+
+  open_api_polymorphic_property(
+    key: :primary_channel,
+    type_field_name: :__type__,
+    open_api_discriminator_property: "channel_type",
+    variants: [
+      email: Email,
+      sms: Sms,
+      webhook: Webhook
+    ]
+  )
+
+  open_api_polymorphic_property(
+    key: :fallback_channel,
+    type_field_name: :__type__,
+    open_api_discriminator_property: "channel_type",
+    variants: [
+      email: Email,
+      sms: Sms,
+      webhook: Webhook
+    ]
+  )
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "dual_channel_notifications" do
+    field :subject, :string
+
+    polymorphic_embeds_one(:primary_channel,
+      types: [email: Email, sms: Sms, webhook: Webhook],
+      type_field_name: :__type__,
+      on_type_not_found: :raise,
+      on_replace: :update
+    )
+
+    polymorphic_embeds_one(:fallback_channel,
+      types: [email: Email, sms: Sms, webhook: Webhook],
+      type_field_name: :__type__,
+      on_type_not_found: :raise,
+      on_replace: :update
+    )
+
+    timestamps()
+  end
+
+  open_api_schema(
+    title: "DualChannelNotification",
+    description: "Notification delivered with a primary channel and an optional fallback",
+    required: [:subject, :primary_channel],
+    properties: [:id, :subject, :primary_channel, :fallback_channel],
+    tags: ["Notification"]
+  )
+
+  def changeset(notification, attrs) do
+    notification
+    |> cast(attrs, [:subject])
+    |> validate_required([:subject])
+    |> cast_polymorphic_embed(:primary_channel, required: true)
+    |> cast_polymorphic_embed(:fallback_channel, required: false)
+  end
+end

--- a/examples/phoenix_ecto_open_api_demo/test/phoenix_ecto_open_api_demo/dual_channel_notification_test.exs
+++ b/examples/phoenix_ecto_open_api_demo/test/phoenix_ecto_open_api_demo/dual_channel_notification_test.exs
@@ -1,0 +1,121 @@
+defmodule PhoenixEctoOpenApiDemo.DualChannelNotificationTest do
+  @moduledoc """
+  End-to-end lock for GH-47. The `DualChannelNotification` schema declares
+  two `open_api_polymorphic_property/1` calls sharing the same variant pool
+  (`Email` / `Sms` / `Webhook`). Before the fix, compiling this module under
+  `--warnings-as-errors` failed with `redefining module ...` warnings on
+  the parent-contextual sibling submodules (and on their derived
+  `ExOpenApiUtils.Mapper` impls).
+
+  This test never touches the DB — the regression is purely at compile +
+  schema-reflection time, plus a Mapper round-trip to prove the shared
+  parent-contextual siblings route both embed keys correctly.
+  """
+  use ExUnit.Case, async: true
+
+  alias OpenApiSpex.Cast
+
+  alias PhoenixEctoOpenApiDemo.NotificationContext.DualChannelNotification
+  alias PhoenixEctoOpenApiDemo.NotificationContext.Email
+  alias PhoenixEctoOpenApiDemo.NotificationContext.Sms
+
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.DualChannelNotificationEmailRequest
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.DualChannelNotificationEmailResponse
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.DualChannelNotificationRequest
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.DualChannelNotificationResponse
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.DualChannelNotificationSmsRequest
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.DualChannelNotificationSmsResponse
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.DualChannelNotificationWebhookRequest
+  alias PhoenixEctoOpenApiDemo.OpenApiSchema.DualChannelNotificationWebhookResponse
+
+  defp resolved_schemas do
+    empty_spec = %OpenApiSpex.OpenApi{
+      info: %OpenApiSpex.Info{title: "test", version: "0"},
+      paths: %{},
+      components: %OpenApiSpex.Components{schemas: %{}}
+    }
+
+    empty_spec
+    |> OpenApiSpex.add_schemas([DualChannelNotificationRequest, DualChannelNotificationResponse])
+    |> then(& &1.components.schemas)
+  end
+
+  describe "GH-47: dedupe parent-contextual siblings across embeds" do
+    test "all six (variant × direction) parent-contextual siblings exist exactly once" do
+      for mod <- [
+            DualChannelNotificationEmailRequest,
+            DualChannelNotificationEmailResponse,
+            DualChannelNotificationSmsRequest,
+            DualChannelNotificationSmsResponse,
+            DualChannelNotificationWebhookRequest,
+            DualChannelNotificationWebhookResponse
+          ] do
+        assert Code.ensure_loaded?(mod), "expected #{inspect(mod)} to be defined"
+        assert function_exported?(mod, :schema, 0)
+      end
+    end
+
+    test "primary_channel and fallback_channel point at the same shared sibling family" do
+      schema = DualChannelNotificationRequest.schema()
+      primary = schema.properties[:primary_channel]
+      fallback = schema.properties[:fallback_channel]
+
+      assert primary.oneOf == fallback.oneOf
+      assert primary.discriminator.propertyName == "channel_type"
+      assert fallback.discriminator.propertyName == "channel_type"
+      assert primary.discriminator.mapping == fallback.discriminator.mapping
+      assert DualChannelNotificationEmailRequest in primary.oneOf
+      assert DualChannelNotificationSmsRequest in primary.oneOf
+    end
+  end
+
+  describe "round-trip through the shared sibling for both embed keys" do
+    test "casts both primary_channel (email) and fallback_channel (sms) on one payload" do
+      payload = %{
+        "subject" => "Order shipped",
+        "primary_channel" => %{
+          "channel_type" => "email",
+          "to" => "to@example.com",
+          "from" => "from@example.com",
+          "body" => "Your order shipped"
+        },
+        "fallback_channel" => %{
+          "channel_type" => "sms",
+          "phone_number" => "+15551234",
+          "body" => "fallback"
+        }
+      }
+
+      schemas = resolved_schemas()
+      schema = Map.fetch!(schemas, "DualChannelNotificationRequest")
+
+      assert {:ok,
+              %DualChannelNotificationRequest{
+                primary_channel: %DualChannelNotificationEmailRequest{
+                  to: "to@example.com",
+                  channel_type: "email"
+                },
+                fallback_channel: %DualChannelNotificationSmsRequest{
+                  phone_number: "+15551234",
+                  channel_type: "sms"
+                }
+              }} = Cast.cast(schema, payload, schemas)
+    end
+
+    test "Mapper.to_map stamps channel_type independently on both embeds" do
+      notification = %DualChannelNotification{
+        id: "851b18d7-0c88-4095-9969-cbe385926420",
+        subject: "Order shipped",
+        primary_channel: %Email{to: "a@x", from: "b@x", body: "primary"},
+        fallback_channel: %Sms{phone_number: "+15551234", body: "fallback"}
+      }
+
+      result = ExOpenApiUtils.Mapper.to_map(notification)
+
+      assert result["primary_channel"]["channel_type"] == "email"
+      assert result["primary_channel"]["to"] == "a@x"
+      assert result["fallback_channel"]["channel_type"] == "sms"
+      assert result["fallback_channel"]["phone_number"] == "+15551234"
+    end
+  end
+end

--- a/lib/ex_open_api_utils.ex
+++ b/lib/ex_open_api_utils.ex
@@ -383,53 +383,42 @@ defmodule ExOpenApiUtils do
       # Access behaviour. The property_attrs list is the variant's
       # reflected attrs plus an inline discriminator %Property{} so the
       # sibling's Mapper emits the discriminator as a real wire field.
-      for decl <- @open_api_polymorphic_properties do
-        entry = Map.fetch!(polymorphic_variants, decl.key)
-
-        for variant <- entry.variant_entries do
-          # Two distinct discriminator stamps happen on the sibling's Mapper
-          # result map, both derived from the same entry + variant inputs:
-          #
-          #   1. WIRE discriminator (e.g. `:destination_type => "webhook"`) —
-          #      `discriminator_prop` is appended to `property_attrs` below so
-          #      the sibling's walker emits it like any other property.
-          #
-          #   2. ECTO type-field discriminator (e.g. `:__type__ => "webhook"`)
-          #      — `self_stamp_atom` / `self_stamp_wire` below are read by
-          #      `Any.__deriving__/3` (GH-34) and spliced as a final
-          #      `Map.put(result, atom, wire)` at the tail of the generated
-          #      walker body, so nested polymorphic cases get their Ecto
-          #      atom at every level without relying on the outer walker's
-          #      `polymorphic_variants` knowing about nested keys.
-          discriminator_prop = %ExOpenApiUtils.Property{
-            key: entry.discriminator_atom,
-            source: entry.discriminator_atom,
-            schema: %OpenApiSpex.Schema{type: :string, enum: [variant.wire]}
-          }
-
-          request_attrs = variant.request_property_attrs ++ [discriminator_prop]
-          response_attrs = variant.response_property_attrs ++ [discriminator_prop]
-
-          Protocol.derive(
-            ExOpenApiUtils.Mapper,
-            variant.parent_contextual_request_submodule,
-            property_attrs: request_attrs,
-            map_direction: :from_open_api,
-            polymorphic_variants: polymorphic_variants,
-            self_stamp_atom: entry.type_field_atom,
-            self_stamp_wire: variant.wire
-          )
-
-          Protocol.derive(
-            ExOpenApiUtils.Mapper,
-            variant.parent_contextual_response_submodule,
-            property_attrs: response_attrs,
-            map_direction: :from_open_api,
-            polymorphic_variants: polymorphic_variants,
-            self_stamp_atom: entry.type_field_atom,
-            self_stamp_wire: variant.wire
-          )
-        end
+      # Two distinct discriminator stamps happen on each sibling's Mapper
+      # result map, both derived from the same entry + variant inputs:
+      #
+      #   1. WIRE discriminator (e.g. `:destination_type => "webhook"`) —
+      #      `discriminator_prop` is appended to `property_attrs` so
+      #      the sibling's walker emits it like any other property.
+      #
+      #   2. ECTO type-field discriminator (e.g. `:__type__ => "webhook"`)
+      #      — `self_stamp_atom` / `self_stamp_wire` are read by
+      #      `Any.__deriving__/3` (GH-34) and spliced as a final
+      #      `Map.put(result, atom, wire)` at the tail of the generated
+      #      walker body, so nested polymorphic cases get their Ecto
+      #      atom at every level without relying on the outer walker's
+      #      `polymorphic_variants` knowing about nested keys.
+      #
+      # GH-47: when a parent declares two `open_api_polymorphic_property`s
+      # with the same variant pool (e.g. two cloud-storage embeds both
+      # backed by [aws: AWS, r2: R2, custom: Custom]), the same target
+      # sibling module would be derived twice and emit a "redefining
+      # module" warning. `__build_dedup_derive_specs__/3` collapses
+      # those duplicates and raises on genuine conflicts.
+      for spec <-
+            ExOpenApiUtils.__build_dedup_derive_specs__(
+              unquote(module),
+              @open_api_polymorphic_properties,
+              polymorphic_variants
+            ) do
+        Protocol.derive(
+          ExOpenApiUtils.Mapper,
+          spec.target_module,
+          property_attrs: spec.property_attrs,
+          map_direction: :from_open_api,
+          polymorphic_variants: polymorphic_variants,
+          self_stamp_atom: spec.self_stamp_atom,
+          self_stamp_wire: spec.self_stamp_wire
+        )
       end
 
       # Synthesize the two directional %Property{} entries per polymorphic
@@ -905,31 +894,22 @@ defmodule ExOpenApiUtils do
       )
       when is_atom(parent_module) and is_list(polymorphic_decls) and
              is_map(polymorphic_variants) and map_size(polymorphic_variants) > 0 do
-    for decl <- polymorphic_decls,
-        entry = Map.fetch!(polymorphic_variants, decl.key),
-        variant <- entry.variant_entries do
-      discriminator_prop = %ExOpenApiUtils.Property{
-        key: entry.discriminator_atom,
-        source: entry.discriminator_atom,
-        schema: %OpenApiSpex.Schema{type: :string, enum: [variant.wire]}
-      }
-
+    # GH-47: dedupe by target module so two decls that share a variant pool
+    # don't call `Module.create/3` twice on the same sibling and emit a
+    # "redefining module" warning. Specs that target the same module but
+    # disagree on body raise a CompileError instead of silently winning.
+    parent_module
+    |> build_sibling_specs(polymorphic_decls, polymorphic_variants)
+    |> dedup_sibling_specs!(parent_module)
+    |> Enum.each(fn spec ->
       create_parent_contextual_sibling!(
-        variant.original_request_submodule,
-        variant.parent_contextual_request_submodule,
-        entry.discriminator_atom,
-        variant.wire,
-        variant.request_property_attrs ++ [discriminator_prop]
+        spec.original_submodule,
+        spec.target_module,
+        spec.discriminator_atom,
+        spec.wire,
+        spec.property_attrs
       )
-
-      create_parent_contextual_sibling!(
-        variant.original_response_submodule,
-        variant.parent_contextual_response_submodule,
-        entry.discriminator_atom,
-        variant.wire,
-        variant.response_property_attrs ++ [discriminator_prop]
-      )
-    end
+    end)
 
     :ok
   end
@@ -940,6 +920,84 @@ defmodule ExOpenApiUtils do
         _polymorphic_variants
       ),
       do: :ok
+
+  defp build_sibling_specs(_parent_module, polymorphic_decls, polymorphic_variants) do
+    for decl <- polymorphic_decls,
+        entry = Map.fetch!(polymorphic_variants, decl.key),
+        variant <- entry.variant_entries,
+        {target_module, original_submodule, base_attrs} <- [
+          {variant.parent_contextual_request_submodule, variant.original_request_submodule,
+           variant.request_property_attrs},
+          {variant.parent_contextual_response_submodule, variant.original_response_submodule,
+           variant.response_property_attrs}
+        ] do
+      discriminator_prop = %ExOpenApiUtils.Property{
+        key: entry.discriminator_atom,
+        source: entry.discriminator_atom,
+        schema: %OpenApiSpex.Schema{type: :string, enum: [variant.wire]}
+      }
+
+      %{
+        decl_key: decl.key,
+        target_module: target_module,
+        original_submodule: original_submodule,
+        discriminator_atom: entry.discriminator_atom,
+        wire: variant.wire,
+        property_attrs: base_attrs ++ [discriminator_prop]
+      }
+    end
+  end
+
+  defp dedup_sibling_specs!(specs, parent_module) do
+    specs
+    |> Enum.group_by(& &1.target_module)
+    |> Enum.map(fn {target_module, group} ->
+      [first | rest] = group
+      first_body = Map.delete(first, :decl_key)
+
+      Enum.each(rest, fn other ->
+        if Map.delete(other, :decl_key) != first_body do
+          raise CompileError,
+            description:
+              "open_api_polymorphic_property declarations #{inspect(first.decl_key)} and " <>
+                "#{inspect(other.decl_key)} on #{inspect(parent_module)} both derive " <>
+                "parent-contextual sibling #{inspect(target_module)} but disagree on " <>
+                "discriminator atom, wire value, or property attrs. Either use distinct " <>
+                "variant pools or align the type_field_name/open_api_discriminator_property " <>
+                "across the two declarations."
+        end
+      end)
+
+      first
+    end)
+  end
+
+  @doc false
+  # GH-47 partner of `__generate_parent_contextual_variants__/3` for the
+  # Mapper Protocol.derive pass: builds the deduped list of derive specs
+  # called from the parent's `__before_compile__` quote. Same dedup
+  # contract — collapse identical (target_module, body) tuples, raise
+  # on collisions whose bodies disagree.
+  def __build_dedup_derive_specs__(parent_module, polymorphic_decls, polymorphic_variants)
+      when is_atom(parent_module) and is_list(polymorphic_decls) and
+             is_map(polymorphic_variants) do
+    parent_module
+    |> build_sibling_specs(polymorphic_decls, polymorphic_variants)
+    |> dedup_sibling_specs!(parent_module)
+    |> Enum.map(fn spec ->
+      entry = Map.fetch!(polymorphic_variants, spec.decl_key)
+
+      %{
+        target_module: spec.target_module,
+        property_attrs: spec.property_attrs,
+        self_stamp_atom: entry.type_field_atom,
+        self_stamp_wire: spec.wire
+      }
+    end)
+  end
+
+  def __build_dedup_derive_specs__(_parent_module, _polymorphic_decls, _polymorphic_variants),
+    do: []
 
   defp create_parent_contextual_sibling!(
          original_submodule,

--- a/test/ex_open_api_utils/polymorphic_dual_embed_test.exs
+++ b/test/ex_open_api_utils/polymorphic_dual_embed_test.exs
@@ -1,0 +1,213 @@
+defmodule ExOpenApiUtils.PolymorphicDualEmbedTest do
+  @moduledoc """
+  GH-47 regression lock: two `open_api_polymorphic_property/1` declarations
+  on the same parent backed by the same variant pool must compile cleanly
+  (no `redefining module` warning) and route both embed keys through the
+  shared parent-contextual sibling correctly.
+
+  See `test/support/polymorphic_discriminator/dual_channel_notification.ex`
+  for the fixture.
+  """
+  use ExUnit.Case, async: true
+
+  alias OpenApiSpex.Cast
+
+  alias ExOpenApiUtilsTest.OpenApiSchema.DualChannelNotificationEmailChannelRequest
+  alias ExOpenApiUtilsTest.OpenApiSchema.DualChannelNotificationEmailChannelResponse
+  alias ExOpenApiUtilsTest.OpenApiSchema.DualChannelNotificationRequest
+  alias ExOpenApiUtilsTest.OpenApiSchema.DualChannelNotificationResponse
+  alias ExOpenApiUtilsTest.OpenApiSchema.DualChannelNotificationSmsChannelRequest
+  alias ExOpenApiUtilsTest.OpenApiSchema.DualChannelNotificationSmsChannelResponse
+  alias ExOpenApiUtilsTest.OpenApiSchema.DualChannelNotificationWebhookChannelRequest
+
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.DualChannelNotification
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.EmailChannel
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.SmsChannel
+
+  defp resolved_schemas do
+    empty_spec = %OpenApiSpex.OpenApi{
+      info: %OpenApiSpex.Info{title: "test", version: "0"},
+      paths: %{},
+      components: %OpenApiSpex.Components{schemas: %{}}
+    }
+
+    empty_spec
+    |> OpenApiSpex.add_schemas([DualChannelNotificationRequest, DualChannelNotificationResponse])
+    |> then(& &1.components.schemas)
+  end
+
+  defp cast_request(payload) do
+    schemas = resolved_schemas()
+    schema = Map.fetch!(schemas, "DualChannelNotificationRequest")
+    Cast.cast(schema, payload, schemas)
+  end
+
+  describe "parent-contextual sibling generation (GH-47 dedupe)" do
+    test "each unique sibling module is generated exactly once and is loadable" do
+      for mod <- [
+            DualChannelNotificationEmailChannelRequest,
+            DualChannelNotificationEmailChannelResponse,
+            DualChannelNotificationSmsChannelRequest,
+            DualChannelNotificationSmsChannelResponse,
+            DualChannelNotificationWebhookChannelRequest
+          ] do
+        assert Code.ensure_loaded?(mod), "expected #{inspect(mod)} to be defined"
+        # OpenApiSpex.schema/1 produces both __struct__/0 and schema/0
+        assert function_exported?(mod, :__struct__, 0)
+        assert function_exported?(mod, :schema, 0)
+      end
+    end
+
+    test "both primary_channel and fallback_channel resolve to the same shared sibling oneOf entries" do
+      request_schema = DualChannelNotificationRequest.schema()
+      primary = request_schema.properties[:primary_channel]
+      fallback = request_schema.properties[:fallback_channel]
+
+      assert primary.oneOf == fallback.oneOf
+      assert primary.discriminator.mapping == fallback.discriminator.mapping
+      assert DualChannelNotificationEmailChannelRequest in primary.oneOf
+    end
+  end
+
+  describe "round-trip through the shared sibling for both keys" do
+    test "primary_channel email payload casts via the shared parent-contextual sibling" do
+      payload = %{
+        "subject" => "Order shipped",
+        "primary_channel" => %{
+          "channel_type" => "email",
+          "to" => "to@example.com",
+          "from" => "from@example.com",
+          "body" => "Your order shipped"
+        }
+      }
+
+      assert {:ok,
+              %DualChannelNotificationRequest{
+                subject: "Order shipped",
+                primary_channel: %DualChannelNotificationEmailChannelRequest{
+                  to: "to@example.com",
+                  channel_type: "email"
+                }
+              }} = cast_request(payload)
+    end
+
+    test "fallback_channel sms payload casts via the same shared sibling family" do
+      payload = %{
+        "subject" => "Order shipped",
+        "primary_channel" => %{
+          "channel_type" => "email",
+          "to" => "to@example.com",
+          "from" => "from@example.com",
+          "body" => "primary"
+        },
+        "fallback_channel" => %{
+          "channel_type" => "sms",
+          "phone_number" => "+15551234",
+          "body" => "fallback"
+        }
+      }
+
+      assert {:ok,
+              %DualChannelNotificationRequest{
+                primary_channel: %DualChannelNotificationEmailChannelRequest{},
+                fallback_channel: %DualChannelNotificationSmsChannelRequest{
+                  phone_number: "+15551234",
+                  channel_type: "sms"
+                }
+              }} = cast_request(payload)
+    end
+
+    test "Mapper.to_map stamps channel_type on both embeds independently" do
+      notification = %DualChannelNotification{
+        id: "851b18d7-0c88-4095-9969-cbe385926420",
+        subject: "hi",
+        primary_channel: %EmailChannel{to: "a@x", from: "b@x", body: "hello"},
+        fallback_channel: %SmsChannel{phone_number: "+15551234", body: "fallback"}
+      }
+
+      result = ExOpenApiUtils.Mapper.to_map(notification)
+
+      assert result["primary_channel"]["channel_type"] == "email"
+      assert result["primary_channel"]["to"] == "a@x"
+      assert result["fallback_channel"]["channel_type"] == "sms"
+      assert result["fallback_channel"]["phone_number"] == "+15551234"
+    end
+
+    test "request-side Mapper.to_map emits :__type__ for both embeds" do
+      request = %DualChannelNotificationRequest{
+        subject: "hi",
+        primary_channel: %DualChannelNotificationEmailChannelRequest{
+          to: "a@x",
+          from: "b@x",
+          body: "hello"
+        },
+        fallback_channel: %DualChannelNotificationSmsChannelRequest{
+          phone_number: "+15551234",
+          body: "fallback"
+        }
+      }
+
+      result = ExOpenApiUtils.Mapper.to_map(request)
+      assert result.primary_channel[:__type__] == "email"
+      assert result.fallback_channel[:__type__] == "sms"
+    end
+  end
+
+  describe "two decls colliding on sibling name with disagreeing bodies (GH-47 raise path)" do
+    test "differing open_api_discriminator_property across decls raises a CompileError" do
+      code = """
+      defmodule Test.PolyDual.DisagreeingDiscriminator do
+        use ExOpenApiUtils
+
+        alias ExOpenApiUtilsTest.PolymorphicDiscriminator.EmailChannel
+        alias ExOpenApiUtilsTest.PolymorphicDiscriminator.SmsChannel
+
+        import PolymorphicEmbed
+
+        open_api_polymorphic_property(
+          key: :primary_channel,
+          type_field_name: :__type__,
+          open_api_discriminator_property: "channel_type",
+          variants: [email: EmailChannel, sms: SmsChannel]
+        )
+
+        open_api_polymorphic_property(
+          key: :fallback_channel,
+          type_field_name: :__type__,
+          open_api_discriminator_property: "other_channel_type",
+          variants: [email: EmailChannel, sms: SmsChannel]
+        )
+
+        @primary_key {:id, :binary_id, autogenerate: true}
+        schema "disagreeing_discriminator" do
+          field(:subject, :string)
+
+          polymorphic_embeds_one(:primary_channel,
+            types: [email: EmailChannel, sms: SmsChannel],
+            type_field_name: :__type__,
+            on_type_not_found: :raise,
+            on_replace: :update
+          )
+
+          polymorphic_embeds_one(:fallback_channel,
+            types: [email: EmailChannel, sms: SmsChannel],
+            type_field_name: :__type__,
+            on_type_not_found: :raise,
+            on_replace: :update
+          )
+        end
+
+        open_api_schema(
+          title: "DisagreeingDiscriminator",
+          description: "x",
+          properties: [:primary_channel, :fallback_channel]
+        )
+      end
+      """
+
+      assert_raise CompileError, ~r/both derive parent-contextual sibling/, fn ->
+        Code.compile_string(code)
+      end
+    end
+  end
+end

--- a/test/support/polymorphic_discriminator/dual_channel_notification.ex
+++ b/test/support/polymorphic_discriminator/dual_channel_notification.ex
@@ -1,0 +1,84 @@
+defmodule ExOpenApiUtilsTest.PolymorphicDiscriminator.DualChannelNotification do
+  @moduledoc """
+  GH-47 fixture. Two `open_api_polymorphic_property/1` declarations on the
+  same parent, both backed by the same variant pool. Before the GH-47 fix
+  this fails compilation under `--warnings-as-errors` with
+  `warning: redefining module ExOpenApiUtilsTest.OpenApiSchema.DualChannelNotification<Variant><Direction>`
+  because the two decls derived identically-named parent-contextual
+  siblings. The fix dedupes generation: each unique target module is
+  built once, since the two decls would produce structurally identical
+  bodies.
+  """
+  use ExOpenApiUtils
+
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.EmailChannel
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.SmsChannel
+  alias ExOpenApiUtilsTest.PolymorphicDiscriminator.WebhookChannel
+
+  import PolymorphicEmbed
+
+  open_api_property(
+    key: :subject,
+    schema: %Schema{type: :string, example: "Order shipped"}
+  )
+
+  open_api_polymorphic_property(
+    key: :primary_channel,
+    type_field_name: :__type__,
+    open_api_discriminator_property: "channel_type",
+    variants: [
+      email: EmailChannel,
+      sms: SmsChannel,
+      webhook: WebhookChannel
+    ]
+  )
+
+  open_api_polymorphic_property(
+    key: :fallback_channel,
+    type_field_name: :__type__,
+    open_api_discriminator_property: "channel_type",
+    variants: [
+      email: EmailChannel,
+      sms: SmsChannel,
+      webhook: WebhookChannel
+    ]
+  )
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "dual_channel_notifications" do
+    field(:subject, :string)
+
+    polymorphic_embeds_one(:primary_channel,
+      types: [email: EmailChannel, sms: SmsChannel, webhook: WebhookChannel],
+      type_field_name: :__type__,
+      on_type_not_found: :raise,
+      on_replace: :update
+    )
+
+    polymorphic_embeds_one(:fallback_channel,
+      types: [email: EmailChannel, sms: SmsChannel, webhook: WebhookChannel],
+      type_field_name: :__type__,
+      on_type_not_found: :raise,
+      on_replace: :update
+    )
+
+    timestamps()
+  end
+
+  open_api_schema(
+    title: "DualChannelNotification",
+    description: "A notification with primary and fallback delivery channels",
+    required: [:subject, :primary_channel],
+    properties: [:id, :subject, :primary_channel, :fallback_channel],
+    tags: ["Notification"]
+  )
+
+  def changeset(notification, attrs) do
+    notification
+    |> cast(attrs, [:subject])
+    |> validate_required([:subject])
+    |> cast_polymorphic_embed(:primary_channel, required: true)
+    |> cast_polymorphic_embed(:fallback_channel, required: false)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -50,6 +50,13 @@ ExOpenApiUtilsTest.CompiledFixtures.stash(
 
 ExOpenApiUtilsTest.CompiledFixtures.stash("test/support/polymorphic_discriminator/analytics.ex")
 
+# GH-47 — two `open_api_polymorphic_property` decls on one parent sharing the
+# same variant pool. Pre-fix this emitted a "redefining module" warning when
+# the two decls' parent-contextual siblings collided.
+ExOpenApiUtilsTest.CompiledFixtures.stash(
+  "test/support/polymorphic_discriminator/dual_channel_notification.ex"
+)
+
 # GH-34 — nested polymorphic fixtures. Webhook-subscription + auth tree that
 # stacks three `open_api_polymorphic_property` macros: Subscription.destination
 # → WebhookDestination.auth → OAuthAuth.grant. Variants must load before their


### PR DESCRIPTION
## Summary

- Fix GH-47: a parent declaring `open_api_polymorphic_property/1` twice with the same variant pool emitted `warning: redefining module ...` and blocked `--warnings-as-errors`.
- Library now dedupes parent-contextual sibling generation (`Module.create/3`) **and** `Protocol.derive` calls by target module. Identical bodies collapse to a single emit; disagreeing bodies raise a focused `CompileError` naming both decl keys.
- Adds dual-embed fixtures and tests in both the library and `examples/phoenix_ecto_open_api_demo`.

## Test plan

- [x] `mix compile --warnings-as-errors` (library) — clean
- [x] `mix test` (library) — 134 tests, 0 failures (7 new in `polymorphic_dual_embed_test.exs`)
- [x] `mix credo` — no issues
- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors` + `mix test` (example app) — 111 tests, 0 failures (4 new in `dual_channel_notification_test.exs`)
- [x] Confirmed disagreement-raises path: two decls with mismatched `open_api_discriminator_property` against the same variant pool now raise a `CompileError` instead of silently overwriting

Closes #47